### PR TITLE
fix html background colour

### DIFF
--- a/css/trongate.css
+++ b/css/trongate.css
@@ -8,6 +8,10 @@
   --alt: #fff;
 }
 
+html {
+  background-color: #000;
+}
+
 body {
   font-family: Tahoma, Geneva, sans-serif;
   margin: 0;


### PR DESCRIPTION
Changed the HTML background to black in so that over scroll doesn't show a white background.

[Simple change while I'm trying to work out the collaboration options for the new docs] 