### PR TITLE
fix alert code block width overflow

### DIFF
--- a/css/docs.css
+++ b/css/docs.css
@@ -118,7 +118,7 @@ h4 {
 
 button, .button {
 	transition: .3s;
-  text-transform: uppercase;  
+  text-transform: uppercase;
 }
 
 .alert {
@@ -221,7 +221,7 @@ code {
 pre {
   font-family: 'Courier New', Courier, monospace;
   font-size: 1em;
-  width: 98%;
+  max-width: 98%;
   margin: 0 auto;
 }
 


### PR DESCRIPTION
Set CSS width to max-width on the code block

<img width="795" alt="Screenshot 2024-05-06 at 12 17 07" src="https://github.com/trongate/trongate-docs/assets/2340486/45f74ae5-ce11-478c-93a5-6fde893584f8">
