### PR TITLE
Suggested info circle styling option

### DIFF
--- a/css/docs.css
+++ b/css/docs.css
@@ -118,7 +118,7 @@ h4 {
 
 button, .button {
 	transition: .3s;
-  text-transform: uppercase;  
+  text-transform: uppercase;
 }
 
 .alert {
@@ -574,7 +574,7 @@ font-size: 0.8em;
 .feature-ref button {
   margin-top: 0;
   margin-left: 4px;
-  padding: 4px 7px 0px 6px;
+  padding: 0;
   line-height: 1.4em;
 }
 

--- a/css/trongate.css
+++ b/css/trongate.css
@@ -130,8 +130,8 @@ button:hover,
 }
 
 .alt {
-  background-color: transparent;
-  border: 1px solid var(--primary);
+  background-color: transparent !important;
+  border: none !important;
   color: #333;
 }
 


### PR DESCRIPTION
Suggestion to streamline the more info (i) button into the text a little more.

<img width="324" alt="Screenshot 2024-05-06 at 12 37 02" src="https://github.com/trongate/trongate-docs/assets/2340486/8650fe7a-c1ac-4fb6-956f-e589ec2f43db">
