### PR TITLE
Add feature ref links and modify JS to allow for function parenthesis

### DIFF
--- a/0060Views/0020basic_view_file_usage.html
+++ b/0060Views/0020basic_view_file_usage.html
@@ -35,7 +35,7 @@ function greeting() {
 </code></pre>
 
 <h3>Introducing, The 'View' Method</h3>
-<p>In order to load view files, Trongate uses an internal method named <span class="feature-ref">url_title</span>. </p>
+<p>In order to load view files, Trongate uses an internal method named <span class="feature-ref">url_title()</span>. </p>
 
 <p>In the example shown, an argument of 'greeting' is being passed into the <code>view()</code> method.  If the <code>view()</code> method is invoked, in this manner, the containing module's 'views' directory will be scanned for a file named 'greeting.php'.  If the file exists, the content of the file will be rendered and sent to the browser.</p>
 
@@ -82,7 +82,7 @@ class Welcome extends Trongate {
   <figure>
     <img src="../images/78/greetingPZK7.png" alt="Screenshot demonstrating the rendering of a simple view file." style="width:100%">
     <figcaption>Screenshot, demonstrating the rendering of a simple view file.</figcaption>
-  </figure> 
+  </figure>
 </div>
 
 <h2>Conclusion</h2>

--- a/0060Views/0030passing_data_into_view_files.html
+++ b/0060Views/0030passing_data_into_view_files.html
@@ -12,15 +12,15 @@ $this->view("welcome", $data);
 <p class="mt-2">Upon loading the view files, the data array is extracted automatically, allowing its elements to be accessed as variables within the view. It is also possible to pass various data types such as objects, arrays, and booleans into view files. Consider the following example, where an array of cities and a weekday are passed to a view:</p>
 <pre class="mt-2"><code>
 function information() {
-    // Create an array of cities 
+    // Create an array of cities
     $cities = ["New York", "London", "Paris"];
-    
+
     // Prepare data array with cities and today's information
     $data = [
         "cities" => $cities,
         "today" => "Monday"
     ];
-    
+
     // Load the view with the data
     $this->view("information", $data);
 }
@@ -57,9 +57,9 @@ function greeting() {
   <figure>
     <img src="../images/75/hello_daBye5.png" alt="xxxx" style="width:100%">
     <figcaption>Screenshot.</figcaption>
-  </figure> 
+  </figure>
 </div>
 
 <div class="alert alert-danger">
-  <p>Extreme caution should be used when rendering data accepted from potentially untrustworthy sources, such as user inputs in online discussion forums. In those scenarios, it is advisable to use the Trongate framework's <span class="feature-ref">out</span> function. This function safely escapes and formats strings for various output contexts, thereby enhancing application security. By ensuring proper encoding for HTML, XML, JSON, JavaScript, or HTML attributes, the <code>out()</code> function helps prevent vulnerabilities such as cross-site scripting (XSS). Proper usage of <code>out()</code> can significantly improve the security of applications when rendering user-generated content.</p>
+  <p>Extreme caution should be used when rendering data accepted from potentially untrustworthy sources, such as user inputs in online discussion forums. In those scenarios, it is advisable to use the Trongate framework's <span class="feature-ref">out()</span> function. This function safely escapes and formats strings for various output contexts, thereby enhancing application security. By ensuring proper encoding for HTML, XML, JSON, JavaScript, or HTML attributes, the <code>out()</code> function helps prevent vulnerabilities such as cross-site scripting (XSS). Proper usage of <code>out()</code> can significantly improve the security of applications when rendering user-generated content.</p>
 </div>

--- a/0120Helpers_Explained/0080other_helpful_features.html
+++ b/0120Helpers_Explained/0080other_helpful_features.html
@@ -21,14 +21,14 @@
 Your IP Address is &lt;?= ip_address() ?&gt;.
 </code></pre></p>
 <h2>Generating Random Strings</h2>
-<p>Trongate has an inbuilt <strong>make_rand_str()</strong> function that can be used to generate random strings. An example of how to use this is shown below:</p>
+<p>Trongate has an inbuilt <span class="feature-ref">make_rand_str()</span> function that can be used to generate random strings. An example of how to use this is shown below:</p>
 <p><pre><code>$str = make_rand_str(32);</code></pre></p>
-<p>The numeric argument that has been passed in represents the length of the random string to be generated. If the boolean value of <strong>true </strong>is <em>also</em> passed into the make_rand_str() method, as a second argument, then the random string that's produced will be in upper case.</p>
+<p>The numeric argument that has been passed in represents the length of the random string to be generated. If the boolean value of <strong>true </strong>is <em>also</em> passed into the <span class="feature-ref">make_rand_str()</span> method, as a second argument, then the random string that's produced will be in upper case.</p>
 <p>For example,<br><pre><code>
 $code = make_rand_str(6, true);
 echo $code; //displays something like "A4WX28"
 </code></pre></p>
-<div class="alert alert-info">Trongate's make_rand_str() method produces strings that do <em>not</em> use problematic characters such as the zero character (0). The reason for avoiding usage of problematic characters is to offer clarity to end users. For example, if a customer called and read out an invoice reference number, over the phone, that contains problematic characters such as zeros, ones and the letter 'L' then this could lead to confusion. Trongate's make_rand_str() method chooses from the following characters, 23456789abcdefghjkmnpqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ.</div>
+<div class="alert alert-info">Trongate's <span class="feature-ref">make_rand_str()</span> method produces strings that do <em>not</em> use problematic characters such as the zero character (0). The reason for avoiding usage of problematic characters is to offer clarity to end users. For example, if a customer called and read out an invoice reference number, over the phone, that contains problematic characters such as zeros, ones and the letter 'L' then this could lead to confusion. Trongate's <span class="feature-ref">make_rand_str()</span> method chooses from the following characters, 23456789abcdefghjkmnpqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ.</div>
 </p>
 <h2>APPPATH</h2>
 <p>If you would like to get the file path (within your computer or server) that leads to your web application, you can do so by calling upon the APPPATH constant.  For example:</p>
@@ -70,4 +70,4 @@ echo "&lt;p&gt;Age: ".out($data["age"], "json")."&lt;/p&gt;";
 echo out($name);
 echo out($email);
 </code></pre></p>
-<div class="alert alert-warning">NOTE: The example above assumes usage within a webpage operating in English with the default UTF-8 character encoding. If your webpage operates in a different language or uses a non-default character encoding, consider supplying an additional argument specifying your desired character encoding for the out() function. This ensures proper handling and display of characters specific to your language or encoding set.</div>
+<div class="alert alert-warning">NOTE: The example above assumes usage within a webpage operating in English with the default UTF-8 character encoding. If your webpage operates in a different language or uses a non-default character encoding, consider supplying an additional argument specifying your desired character encoding for the <span class="feature-ref">out()</span> function. This ensures proper handling and display of characters specific to your language or encoding set.</div>

--- a/docs_feature_ref_content.php
+++ b/docs_feature_ref_content.php
@@ -66,10 +66,10 @@ if (segment(3) === '') {
 
 	if (isset($features_items)) {
 		foreach($features_items as $feature_item) {
-			echo '<li class="feature-item" id="feature-li-'.$feature_item.'"><span class="feature-ref">'.$feature_item.'</span>';
+			echo '<li class="feature-item" id="feature-li-'.$feature_item.'"><span class="feature-ref">'.$feature_item.'()</span>';
 			echo '<div class="sm"><span class="blink">* fetching description *</span></div>';
 			echo '</li>';
-		}		
+		}
 	}
 	?>
 </ul>

--- a/js/docs.js
+++ b/js/docs.js
@@ -1,7 +1,7 @@
 const delayTime = 10;
 
 function fetchFeatureItemsInfo() {
-    
+
     const targetFeatureRefs = [];
     const featureItems = document.querySelectorAll('.feature-item');
     featureItems.forEach(targetEl => {
@@ -30,7 +30,7 @@ function fetchFeatureItemsInfo() {
 
         }
     }
-    
+
 }
 
 async function populateFeatureDescriptions(responseText) {
@@ -65,7 +65,7 @@ function buildFeatureRefs() {
     const featureRefs = document.querySelectorAll('.feature-ref');
 
     featureRefs.forEach(featureRefEl => {
-        const refName = featureRefEl.innerHTML;
+        const refName = featureRefEl.innerHTML.replace(/[()]/g, '');
         const featureRefUrl = existingFeatureRefs[refName] || false;
         if (featureRefUrl === false) {
             featureRefEl.classList.remove('feature-ref');
@@ -79,8 +79,8 @@ function buildFeatureRefs() {
             btn.innerHTML = '<i class="fa fa-info-circle"></i>';
             btn.setAttribute('type', 'button');
             btn.setAttribute('class', 'alt');
-            btn.setAttribute('onclick', 'initOpenInfo(\'' + featurePath + '\')');           
-            featureRefEl.appendChild(btn);            
+            btn.setAttribute('onclick', 'initOpenInfo(\'' + featurePath + '\')');
+            featureRefEl.appendChild(btn);
         }
 
     });


### PR DESCRIPTION
Added feature-ref links for any existing references to string helper functions and modified JS to allow for (strip out) parenthesis in the inner HTML (so as to have them more easily identified as functions in the docs)