### PR TITLE
bring back scrollbar to left nav

### DIFF
--- a/css/docs.css
+++ b/css/docs.css
@@ -60,12 +60,12 @@ header {
 
 .container-lg:nth-child(2) aside {
   padding-top: 33px;
-	min-width: max-content;
-	scrollbar-width: thin;
-	display: flex;
-	flex-grow: 1;
-  overflow-y: scroll;
   padding-right: 12px;
+  min-width: max-content;
+  height: 100%;
+  max-height: calc(100vh - 20px);
+  overflow-y: auto;
+  scrollbar-width: thin;
 }
 
 main {

--- a/js/docs.js
+++ b/js/docs.js
@@ -215,7 +215,7 @@ function adjustAsideHeight() {
 document.addEventListener("DOMContentLoaded", function() {
     // Make the <code> elements look beautiful!
     beautifyCodeBlocks();
-    // resize aside match main
+    // resize aside to match main
     adjustAsideHeight();
 
     // Make the alert divs fantasticola!

--- a/js/docs.js
+++ b/js/docs.js
@@ -202,9 +202,21 @@ function goToDocsHome(url) {
     window.location.href = url;
 }
 
+function adjustAsideHeight() {
+    var mainHeight = document.querySelector('main').offsetHeight;
+    var aside = document.querySelector('aside');
+    var asideHeight = aside.offsetHeight;
+
+    if (mainHeight > asideHeight) {
+        aside.style.maxHeight = mainHeight + 'px';
+    }
+}
+
 document.addEventListener("DOMContentLoaded", function() {
     // Make the <code> elements look beautiful!
     beautifyCodeBlocks();
+    // resize aside match main
+    adjustAsideHeight();
 
     // Make the alert divs fantasticola!
     const alertEls = document.querySelectorAll('.alert');
@@ -304,6 +316,10 @@ document.getElementById('scrollToTopBtn').addEventListener('click', function() {
         top: 0,
         behavior: 'smooth' // Enable smooth scrolling
     });
+});
+
+document.addEventListener('resize', function() {
+    adjustAsideHeight();
 });
 
 buildFeatureRefs();


### PR DESCRIPTION
Enable the left-nav scrollbar which had some CSS there but was not showing it because there was no max-height defined.

Also, added JavaScript to auto-size the left-nav `aside` if `main` is larger, but it doesn't always, even though both heights end up the same - any help with this would be appreciated._

There might be some more tweaks to this as I'm not entirely happy with the way the scrollbar size grows tall on some pages _- any help with this also would be appreciated._