### PR TITLE
Added keyboard bindings for page navigation

### DIFF
--- a/js/docs.js
+++ b/js/docs.js
@@ -322,7 +322,7 @@ document.addEventListener('resize', function() {
     adjustAsideHeight();
 });
 
-// Keyboard bindings bindings for page navigation 
+// Keyboard bindings for page navigation 
 document.addEventListener('keydown', function(event) {
     const isAltKey = event.altKey;
 

--- a/js/docs.js
+++ b/js/docs.js
@@ -322,4 +322,43 @@ document.addEventListener('resize', function() {
     adjustAsideHeight();
 });
 
+// Keyboard bindings bindings for page navigation 
+document.addEventListener('keydown', function(event) {
+    const isAltKey = event.altKey;
+
+    if ((isAltKey && (event.key === 'ArrowUp')) || event.key === "h") {
+        window.location.href = baseUrl;
+    }
+
+    if (event.key === 't') {
+        window.location.href = baseUrl + 'introduction/table-of-contents.html';
+    }
+
+    if (event.key === 'w') {
+        window.location.href = baseUrl + 'introduction/welcome.html';
+    }
+
+    if ((isAltKey && event.key === 'ArrowDown') || (event.key === "r")) {
+        window.location.href = baseUrl + 'trongate-api-reference';
+    }
+
+    if (event.key === 'ArrowLeft') {
+        const prevButton = document.querySelector('.page-nav-btns .fa-arrow-circle-left');
+        if (prevButton) {
+            const prevAnchor = prevButton.closest('a');
+            if (prevAnchor) {
+                window.location.href = prevAnchor.href;
+            }
+        }
+    } else if (event.key === 'ArrowRight') {
+        const nextButton = document.querySelector('.page-nav-btns .fa-arrow-circle-right');
+        if (nextButton) {
+            const nextAnchor = nextButton.closest('a');
+            if (nextAnchor) {
+                window.location.href = nextAnchor.href;
+            }
+        }
+    }
+});
+
 buildFeatureRefs();


### PR DESCRIPTION
- Implemented keyboard bindings for easier page navigation in the documentation.
- Navigation key bindings include:
  - `Alt/Option + ArrowUp` or `h` to navigate to the home page.
  - `t` to navigate to the table of contents.
  - `w` to navigate to the welcome page.
  - `Alt/Option + ArrowDown` or `r` to navigate to the API reference page.
  - `ArrowLeft` to navigate to the previous page if a previous button is present.
  - `ArrowRight` to navigate to the next page if a next button is present.
- This change enhances the user experience by allowing quick and intuitive navigation through keyboard shortcuts.