### PR TITLE
Removed direct keys from key binding

### DIFF
--- a/js/docs.js
+++ b/js/docs.js
@@ -326,19 +326,11 @@ document.addEventListener('resize', function() {
 document.addEventListener('keydown', function(event) {
     const isAltKey = event.altKey;
 
-    if ((isAltKey && (event.key === 'ArrowUp')) || event.key === "h") {
-        window.location.href = baseUrl;
-    }
-
-    if (event.key === 't') {
-        window.location.href = baseUrl + 'introduction/table-of-contents.html';
-    }
-
-    if (event.key === 'w') {
+    if (isAltKey && event.key === 'ArrowUp') {
         window.location.href = baseUrl + 'introduction/welcome.html';
     }
 
-    if ((isAltKey && event.key === 'ArrowDown') || (event.key === "r")) {
+    if (isAltKey && event.key === 'ArrowDown') {
         window.location.href = baseUrl + 'trongate-api-reference';
     }
 


### PR DESCRIPTION
Removed 'r', 'w' & 't' direct keys from key binding which was causing issues on a Mac.

The default keys are:
- alt/ option arrow up to jump to the Welcome page
- alt/ option arrow down to jump to Trongate API Reference page
- left arrow - when there is a 'prev' button on the page it will take you to the previous page
- right arrow - when there is a 'next' button on the page it will take you to the next page

I may enhance this soon with a user-defined configuration so that you can assign keys and qualifiers to your liking for Mac, PC and Linux.