### PR TITLE
Replace <pre> tags with custom [code=php] code tags across reference files

### DIFF
--- a/assets/reference/class_reference/The_Modules_Class/load.html
+++ b/assets/reference/class_reference/The_Modules_Class/load.html
@@ -48,7 +48,7 @@ $this->modules->load("welcome");[/code]
     <p>The main Trongate class provides the <code>module()</code> method as a convenient alias to <code>$this->modules->load()</code>. This method offers a semantically clear alternative for developers, ensuring the codebase remains expressive and maintainable while utilizing the same underlying functionality as the <code>load()</code> method.</p>
 
     <h3>Example Usage of Alternative Technique</h3>
-    <pre>$this->module('welcome');</pre>
+    [code=php]$this-&gt;module('welcome');[/code]
 
 </div>
 </div>

--- a/assets/reference/helpers/String_Helpers/extract_content.html
+++ b/assets/reference/helpers/String_Helpers/extract_content.html
@@ -59,12 +59,12 @@
   </table>
   <h2>Example Usage</h2>
   <div>
-    <pre>
+    [code=php]
 $string = "Hello, start here and end here, thanks.";
 $start_delim = "start here";
 $end_delim = "end here";
-$extracted = $this->extract_content($string, $start_delim, $end_delim);
+$extracted = $this-&gt;extract_content($string, $start_delim, $end_delim);
 // $extracted will be " and "
-    </pre>
+    [/code]
   </div>
 </div>

--- a/assets/reference/helpers/String_Helpers/filter_name.html
+++ b/assets/reference/helpers/String_Helpers/filter_name.html
@@ -44,10 +44,10 @@
   </table>
   <h2>Example Usage</h2>
   <div>
-    <pre>
+    [code=php]
 $input_name = '&lt;script&gt;alert("Hello");&lt;/script&gt;';
 $allowed_chars = ['-', '_'];
 echo filter_name($input_name, $allowed_chars);
-// Output: 'alert("Hello");'</pre>
+// Output: 'alert("Hello");'[/code]
   </div>
 </div>

--- a/assets/reference/helpers/String_Helpers/filter_str.html
+++ b/assets/reference/helpers/String_Helpers/filter_str.html
@@ -45,10 +45,10 @@
   </table>
   <h2>Example Usage</h2>
   <div>
-    <pre>
+    [code=php]
 $input_string = '&lt;script&gt;alert("Hello");&lt;/script&gt;';
 $allowed_tags = ['&lt;p&gt;', '&lt;a&gt;'];
 echo filter_str($input_string, $allowed_tags);
-// Output: 'alert("Hello");'</pre>
+// Output: 'alert("Hello");'[/code]
   </div>
 </div>

--- a/assets/reference/helpers/String_Helpers/filter_string.html
+++ b/assets/reference/helpers/String_Helpers/filter_string.html
@@ -50,10 +50,10 @@
   </table>
   <h2>Example Usage</h2>
   <div>
-    <pre>
+    [code=php]
 $input_string = '&lt;script&gt;alert("Hello");&lt;/script&gt;';
 $allowed_tags = ['&lt;p&gt;', '&lt;a&gt;'];
 echo filter_string($input_string, $allowed_tags);
-// Output: 'alert("Hello");'</pre>
+// Output: 'alert("Hello");'[/code]
   </div>
 </div>

--- a/assets/reference/helpers/String_Helpers/get_last_part.html
+++ b/assets/reference/helpers/String_Helpers/get_last_part.html
@@ -47,11 +47,11 @@
   </table>
   <h2>Example Usage</h2>
   <div>
-    <pre>
+    [code=php]
 echo get_last_part("example-string-123");
 // Output: '123'
 
 echo get_last_part("example string", ' ');
-// Output: 'string'</pre>
+// Output: 'string'[/code]
   </div>
 </div>

--- a/assets/reference/helpers/String_Helpers/nice_price.html
+++ b/assets/reference/helpers/String_Helpers/nice_price.html
@@ -47,8 +47,8 @@
   </table>
   <h2>Example Usage</h2>
   <div>
-    <pre>
+    [code=php]
 echo nice_price(123456.00); // Output: 123,456
-echo nice_price(123456.78, '$'); // Output: $123,456.78</pre>
+echo nice_price(123456.78, '$'); // Output: $123,456.78[/code]
   </div>
 </div>

--- a/assets/reference/helpers/String_Helpers/remove_substr_between.html
+++ b/assets/reference/helpers/String_Helpers/remove_substr_between.html
@@ -73,11 +73,11 @@
 <p>Note that <b>&lt;b&gt;Macbeth&lt;/b&gt;</b> appears more than once in the <code>$haystack</code> variable. However, only the first instance of a matching substring is being removed.</p> 
 
   <div>
-    <pre>$start = '&lt;b&gt;';
+    [code=php]$start = '&lt;b&gt;';
 $end = '&lt;/b&gt;';
 $haystack = 'When &lt;b&gt;Macbeth&lt;/b&gt; speaks, all listen. &lt;b&gt;Macbeth&lt;/b&gt; is a forbidden word.';
 echo remove_substr_between($start, $end, $haystack);
-// Output:   When  speaks, all listen. &lt;b&gt;Macbeth&lt;/b&gt; is a forbidden word.</pre>
+// Output:   When  speaks, all listen. &lt;b&gt;Macbeth&lt;/b&gt; is a forbidden word.[/code]
   </div>
 
 <h2>Example #2</h2>
@@ -85,11 +85,11 @@ echo remove_substr_between($start, $end, $haystack);
 
 
   <div>
-    <pre>$start = '&lt;b&gt;';
+    [code=php]$start = '&lt;b&gt;';
 $end = '&lt;/b&gt;';
 $haystack = 'When &lt;b&gt;Macbeth&lt;/b&gt; speaks, all listen. &lt;b&gt;Macbeth&lt;/b&gt; is a forbidden word.';
 echo remove_substr_between($start, $end, $haystack, true);
-// Output:   When  speaks, all listen.  is a forbidden word.</pre>
+// Output:   When  speaks, all listen.  is a forbidden word.[/code]
   </div>
 
 

--- a/assets/reference/helpers/String_Helpers/replace_html_tags.html
+++ b/assets/reference/helpers/String_Helpers/replace_html_tags.html
@@ -47,7 +47,7 @@
   </table>
   <h2>Example Usage</h2>
   <div>
-    <pre>
+    [code=php]
 $html_content = "&lt;div class='content'&gt;&lt;p&gt;This is some content.&lt;/p&gt;&lt;/div&gt;";
 $specifications = [
     'opening_string_before' => '&lt;p&gt;',
@@ -57,6 +57,6 @@ $specifications = [
 ];
 $modified_content = replace_html_tags($html_content, $specifications);
 echo $modified_content;
-// Output: &lt;div class='content'&gt;&lt;div&gt;This is some content.&lt;/div&gt;&lt;/div&gt;</pre>
+// Output: &lt;div class='content'&gt;&lt;div&gt;This is some content.&lt;/div&gt;&lt;/div&gt;[/code]
   </div>
 </div>

--- a/assets/reference/helpers/String_Helpers/truncate_words.html
+++ b/assets/reference/helpers/String_Helpers/truncate_words.html
@@ -47,8 +47,8 @@
   </table>
   <h2>Example Usage</h2>
   <div>
-    <pre>
+    [code=php]
 echo truncate_words("Hello World! This is a Test String for example purposes.", 5);
-// Output: Hello World! This is a...</pre>
+// Output: Hello World! This is a...[/code]
   </div>
 </div>

--- a/assets/reference/helpers/String_Helpers/url_title.html
+++ b/assets/reference/helpers/String_Helpers/url_title.html
@@ -47,8 +47,8 @@
   </table>
   <h2>Example Usage</h2>
   <div>
-    <pre>
+    [code=php]
 echo url_title("Hello World! This is a Test String.");
-// Output: hello-world-this-is-a-test-string</pre>
+// Output: hello-world-this-is-a-test-string[/code]
   </div>
 </div>

--- a/assets/reference/helpers/Utilities_Helpers/ip_address.html
+++ b/assets/reference/helpers/Utilities_Helpers/ip_address.html
@@ -22,8 +22,8 @@
   </table>
   <h2>Example Usage</h2>
   <div>
-    <pre>
+    [code=php]
 echo ip_address();
-// Output: Client's IP address.</pre>
+// Output: Client's IP address.[/code]
   </div>
 </div>

--- a/assets/reference/helpers/Utilities_Helpers/return_file_info.html
+++ b/assets/reference/helpers/Utilities_Helpers/return_file_info.html
@@ -41,12 +41,12 @@
   </table>
   <h2>Example Usage</h2>
   <div>
-    <pre>
+    [code=php]
 $file_info = return_file_info("/path/to/your/file.jpg");
 echo "File Name: " . $file_info['file_name'] . "\n";
 echo "File Extension: " . $file_info['file_extension'] . "\n";
 // Output:
 // File Name: file
-// File Extension: .jpg</pre>
+// File Extension: .jpg[/code]
   </div>
 </div>

--- a/assets/reference/helpers/Utilities_Helpers/sort_by_property.html
+++ b/assets/reference/helpers/Utilities_Helpers/sort_by_property.html
@@ -53,7 +53,7 @@
 
   <h2>Example #1</h2>
   <p>The code sample below demonstrates basic usage of the <code>sort_by_property</code> function with default parameters.</p>
-  <pre>
+  [code=php]
   $data = [
       ['name' => 'John', 'age' => 28],
       ['name' => 'Jane', 'age' => 24],
@@ -67,11 +67,11 @@
   //   ['name' => 'John', 'age' => 28],
   //   ['name' => 'Doe', 'age' => 32],
   // ]
-  </pre>
+  [/code]
 
   <h2>Example #2</h2>
   <p>The code sample below demonstrates a more complex usage of the <code>sort_by_property</code> function, sorting in descending order.</p>
-  <pre>
+  [code=php]
   $data = [
       ['name' => 'Apple', 'price' => 3.5],
       ['name' => 'Orange', 'price' => 2.75],
@@ -85,7 +85,7 @@
   //   ['name' => 'Orange', 'price' => 2.75],
   //   ['name' => 'Banana', 'price' => 1.25],
   // ]
-  </pre>
+  [/code]
 
   <h2>Notes</h2>
   <p>If the specified property does not exist in any of the associative arrays, the behavior of the function may be unpredictable. Ensure that the property exists in each array element before calling this function.</p>

--- a/assets/reference/helpers/Utilities_Helpers/sort_rows_by_property.html
+++ b/assets/reference/helpers/Utilities_Helpers/sort_rows_by_property.html
@@ -53,7 +53,7 @@
 
   <h2>Example #1</h2>
   <p>The code sample below demonstrates basic usage of the <code>sort_rows_by_property</code> function with default parameters.</p>
-  <pre>
+  [code=php]
   $data = [
       (object) ['name' => 'John', 'age' => 28],
       (object) ['name' => 'Jane', 'age' => 24],
@@ -67,11 +67,11 @@
   //   (object) ['name' => 'John', 'age' => 28],
   //   (object) ['name' => 'Doe', 'age' => 32],
   // ]
-  </pre>
+  [/code]
 
   <h2>Example #2</h2>
   <p>The code sample below demonstrates a more complex usage of the <code>sort_rows_by_property</code> function, sorting in descending order.</p>
-  <pre>
+  [code=php]
   $data = [
       (object) ['name' => 'Apple', 'price' => 3.5],
       (object) ['name' => 'Orange', 'price' => 2.75],
@@ -85,7 +85,7 @@
   //   (object) ['name' => 'Orange', 'price' => 2.75],
   //   (object) ['name' => 'Banana', 'price' => 1.25],
   // ]
-  </pre>
+  [/code]
 
   <h2>Notes</h2>
   <p>If the specified property does not exist in any of the objects, the behavior of the function may be unpredictable. Ensure that the property exists in each object before calling this function.</p>

--- a/assets/reference/helpers/url_helpers/get_last_segment.html
+++ b/assets/reference/helpers/url_helpers/get_last_segment.html
@@ -42,6 +42,6 @@
   </table>
   <h2>Example Usage</h2>
   <div>
-    <pre>$invoice_ref = get_last_segment();</pre>
+    [code=php]$invoice_ref = get_last_segment();[/code]
   </div>
 </div>

--- a/assets/reference/helpers/url_helpers/get_num_segments.html
+++ b/assets/reference/helpers/url_helpers/get_num_segments.html
@@ -42,6 +42,6 @@
   </table>
   <h2>Example Usage</h2>
   <div>
-    <pre>$num_url_segments = get_num_segments();</pre>
+    [code=php]$num_url_segments = get_num_segments();[/code]
   </div>
 </div>

--- a/assets/reference/helpers/url_helpers/remove_query_string.html
+++ b/assets/reference/helpers/url_helpers/remove_query_string.html
@@ -41,8 +41,8 @@
   </table>
   <h2>Example Usage</h2>
   <div>
-    <pre>
+    [code=php]
 echo remove_query_string("https://example.com/page?param=value");
-// Output: https://example.com/page</pre>
+// Output: https://example.com/page[/code]
   </div>
 </div>

--- a/assets/reference/included/trongate_administrators/login.html
+++ b/assets/reference/included/trongate_administrators/login.html
@@ -11,7 +11,7 @@
 <h2>Accessing The Login Page</h2>
   <p>The default administration login page is accessible by navigating to a Trongate application's base URL followed by <b>tg-admin</b>. However, this URL can be customized to a preferred secret login URL by adjusting the 'Trongate_administrators.php' class.</p>
   <p>To set a secret login URL, uncomment the line:</p>
-  <pre>// private $secret_login_segment = 'tg-admin';</pre>
+  [code=php]// private $secret_login_segment = 'tg-admin';[/code]
   <p>Subsequently, update the <b>$secret_login_segment</b> variable with the desired URL segment to set an alternative login URL.</p>
 
   <h2>Parameters</h2>
@@ -51,13 +51,13 @@
   <h2>Example #1</h2>
   <p>The code below illustrates how to create a hyperlink that redirects users to the admin login page upon clicking.  The assumption, for this example, is that the code would be added inside a view file or an HTML template:</p>
   <div>
-    <pre>&lt;?= anchor('tg-admin', 'Admin Login') ?&gt;</pre>
+    [code=php]&lt;?= anchor('tg-admin', 'Admin Login') ?&gt;[/code]
   </div>
 
   <h2>Example #2</h2>
   <p>In this alternative example, a CSS class, named as 'button', is added to a <b>login</b> hyperlink.  This gives the hyperlink the appearance and behaviour of a button:</p>
   <div>
-    <pre>&lt;?= anchor('tg-admin', 'Admin Login', array('class' => 'button')) ?&gt;</pre>
+    [code=php]&lt;?= anchor('tg-admin', 'Admin Login', array('class' => 'button')) ?&gt;[/code]
   </div>
 
 </div>

--- a/assets/reference/included/trongate_administrators/submit_login.html
+++ b/assets/reference/included/trongate_administrators/submit_login.html
@@ -11,8 +11,8 @@
     <p>
       To change the destination users are sent to upon successful login, modify the <b>$dashboard_home</b> variable at the top of the <b>Trongate_administrators</b> class. By default, it is set to <b>'trongate_pages/manage'</b>. For example:
    </p>
-    <pre>// Where to redirect after successful login.
-private $dashboard_home = 'custom_path/dashboard';</pre>
+    [code=php]// Where to redirect after successful login.
+private $dashboard_home = 'custom_path/dashboard';[/code]
   <h2>Parameters</h2>
   <table>
     <thead>
@@ -48,6 +48,6 @@ private $dashboard_home = 'custom_path/dashboard';</pre>
   </table>
   <h2>Example Usage</h2>
   <div>
-    <pre>// Example Usage not available for this method</pre>
+    [code]// Example Usage not available for this method[/code]
   </div>
 </div>


### PR DESCRIPTION
This PR replaces all `<pre>` HTML tags with custom `[code=php]` code tags across the reference documentation files, improving readability and consistency with the rest of the documentation format.