### PR TITLE
Update included modules list to 17 (remove tasks and endpoint_listener)

### DIFF
--- a/assets/php_framework/0050Module_Fundamentals/0080introducing_included_modules.html
+++ b/assets/php_framework/0050Module_Fundamentals/0080introducing_included_modules.html
@@ -11,7 +11,6 @@
 <p class="sm">Here's all the modules that are included with the Trongate framework.  Click any module name for more details.</p>
 <ul class="modules-list">
     <li><a href="documentation-ref/list_refs/included/db" target="_blank">db</a> ← full database power, no ORM</li>
-    <li><a href="documentation-ref/list_refs/included/endpoint_listener" target="_blank">endpoint_listener</a> ← receive &amp; track API calls</li>
     <li><a href="documentation-ref/list_refs/included/file" target="_blank">file</a> ← upload, download, delete</li>
     <li><a href="documentation-ref/list_refs/included/flashdata" target="_blank">flashdata</a> ← flash messages for redirects</li>
     <li><a href="documentation-ref/list_refs/included/form" target="_blank">form</a> ← build &amp; process forms</li>
@@ -19,7 +18,6 @@
     <li><a href="documentation-ref/list_refs/included/language" target="_blank">language</a> ← multi-language support</li>
     <li><a href="documentation-ref/list_refs/included/pagination" target="_blank">pagination</a> ← beautiful links in 3 seconds</li>
     <li><a href="documentation-ref/list_refs/included/string_service" target="_blank">string_service</a> ← string manipulation made easy</li>
-    <li><a href="documentation-ref/list_refs/included/tasks" target="_blank">tasks</a> ← background job management</li>
     <li><a href="documentation-ref/list_refs/included/templates" target="_blank">templates</a> ← layouts &amp; partials</li>
     <li><a href="documentation-ref/list_refs/included/trongate_administrators" target="_blank">trongate_administrators</a> ← full admin panel</li>
     <li><a href="documentation-ref/list_refs/included/trongate_control" target="_blank">trongate_control</a> ← inspect running modules</li>


### PR DESCRIPTION
Aligned with the changes made to validacious:\n\n- Removed **endpoint_listener** (module deleted from framework)\n- Removed **tasks** (module deleted from framework)\n- List now contains 17 modules, matching validacious exactly