### PR TITLE
Add flashdata module reference directory (manifest + set_flashdata + flashdata methods)

### DIFF
--- a/assets/reference/included/flashdata/flashdata.html
+++ b/assets/reference/included/flashdata/flashdata.html
@@ -1,0 +1,135 @@
+<div class="container">
+ <h1>flashdata()</h1>
+ <p class="signature">public function flashdata(array $data = []): ?string</p>
+
+ <h2>Description</h2>
+ <div class="description">
+ <p>
+ Retrieves and returns a one-time flash message from the session. If a message was previously stored via <code>set_flashdata()</code>, this method returns it wrapped in HTML and immediately clears the session variable so the message is never displayed again.
+ </p>
+ <p>
+ The method handles the following behaviour:
+ </p>
+ <ul>
+ <li>If no flash message exists in the session, <code>null</code> is returned — no output is generated.</li>
+ <li>The message is automatically cleared from the session upon retrieval, ensuring it displays only once.</li>
+ <li>Custom HTML wrapping can be provided via the <code>$data</code> array for one-off overrides.</li>
+ <li>If no custom wrapping is provided, the module checks for globally defined <code>FLASHDATA_OPEN</code> and <code>FLASHDATA_CLOSE</code> constants.</li>
+ <li>If no constants are defined either, a default green <code>&lt;p&gt;</code> tag is used as a fallback.</li>
+ </ul>
+ </div>
+
+ <h2>Parameters</h2>
+ <table class="params-table">
+ <thead>
+ <tr>
+ <th>Parameter</th>
+ <th>Type</th>
+ <th>Description</th>
+ </tr>
+ </thead>
+ <tbody>
+ <tr>
+ <td><code>$data</code></td>
+ <td>array</td>
+ <td>An optional associative array controlling the HTML wrapping of the message. See the <strong>$data Keys</strong> section below for available keys.</td>
+ </tr>
+ </tbody>
+ </table>
+
+ <h3>$data Keys</h3>
+ <table class="params-table">
+ <thead>
+ <tr>
+ <th>Key</th>
+ <th>Type</th>
+ <th>Description</th>
+ <th>Default</th>
+ <th>Required</th>
+ </tr>
+ </thead>
+ <tbody>
+ <tr>
+ <td><code>opening_html</code></td>
+ <td>string|null</td>
+ <td>The HTML string to prepend before the message content. For example: <code>'&lt;div class="alert alert-success"&gt;'</code>. When <code>null</code>, the module falls back to the <code>FLASHDATA_OPEN</code> constant, or a default <code>'&lt;p style="color: green;"&gt;'</code> tag.</td>
+ <td>null</td>
+ <td>No</td>
+ </tr>
+ <tr>
+ <td><code>closing_html</code></td>
+ <td>string|null</td>
+ <td>The HTML string to append after the message content. For example: <code>'&lt;/div&gt;'</code>. When <code>null</code>, the module falls back to the <code>FLASHDATA_CLOSE</code> constant, or a default <code>'&lt;/p&gt;'</code> tag.</td>
+ <td>null</td>
+ <td>No</td>
+ </tr>
+ </tbody>
+ </table>
+
+ <h2>Return Value</h2>
+ <table>
+ <thead>
+ <tr>
+ <th>Type</th>
+ <th>Description</th>
+ </tr>
+ </thead>
+ <tbody>
+ <tr>
+ <td>string|null</td>
+ <td>
+ <strong><code>string</code></strong> — The formatted message with HTML wrapping, ready for output.<br>
+ <strong><code>null</code></strong> — No flash message was found in the session.
+ </td>
+ </tr>
+ </tbody>
+ </table>
+
+ <h2>Example #1: Basic Usage with Helper Function</h2>
+ <p>In your view file, simply call <code>flashdata()</code> with no arguments to display the message with default formatting.</p>
+ <pre><code>&lt;?php
+// In your view file
+flashdata();
+?&gt;</code></pre>
+ <p>This outputs something like <code>&lt;p style="color: green;"&gt;Record created successfully&lt;/p&gt;</code> if a message exists, or nothing if there is no message.</p>
+
+ <h2>Example #2: Custom HTML Wrapping</h2>
+ <p>Pass custom opening and closing HTML to match your application's design system.</p>
+ <pre><code>&lt;?php
+flashdata([
+    'opening_html' => '&lt;div class="alert alert-success" role="alert"&gt;',
+    'closing_html' => '&lt;/div&gt;'
+]);
+?&gt;</code></pre>
+
+ <h2>Example #3: Using Global Defaults via Config Constants</h2>
+ <p>Define <code>FLASHDATA_OPEN</code> and <code>FLASHDATA_CLOSE</code> in your <code>config/config.php</code> file to set a global default style for all flash messages across your application.</p>
+ <pre><code>&lt;?php
+// In config/config.php
+define('FLASHDATA_OPEN', '&lt;div class="toast toast-success"&gt;');
+define('FLASHDATA_CLOSE', '&lt;/div&gt;');
+?&gt;</code></pre>
+ <p>With these constants defined, calls to <code>flashdata()</code> with no arguments will automatically use your custom wrapping.</p>
+
+ <h2>Example #4: Using the Module Directly</h2>
+ <p>For explicit routing, call the module method via <code>Modules::run()</code>. This is equivalent to the helper function but gives you direct access to the module method.</p>
+ <pre><code>&lt;?php
+$message = Modules::run('flashdata/flashdata', [
+    'opening_html' => '&lt;div class="custom-notification"&gt;',
+    'closing_html' => '&lt;/div&gt;'
+]);
+
+if ($message !== null) {
+    echo $message;
+}
+?&gt;</code></pre>
+
+ <h2>Notes</h2>
+ <ul>
+ <li><strong>One-time only:</strong> The message is automatically removed from the session after retrieval. Refreshing the page will not show the message again.</li>
+ <li><strong>Customisation hierarchy:</strong> Function arguments take precedence over config constants, which take precedence over the default green <code>&lt;p&gt;</code> tag.</li>
+ <li><strong>Null-safe:</strong> It is safe to call <code>flashdata()</code> at any time — whether or not a message exists. If no message is present, <code>null</code> is returned and no output is generated.</li>
+ <li><strong>Paired with set_flashdata():</strong> This method is designed to work in tandem with <code>set_flashdata()</code>. Call <code>set_flashdata()</code> before a redirect, then call <code>flashdata()</code> in the destination view.</li>
+ </ul>
+
+</div>

--- a/assets/reference/included/flashdata/flashdata.html
+++ b/assets/reference/included/flashdata/flashdata.html
@@ -87,42 +87,33 @@
 
  <h2>Example #1: Basic Usage with Helper Function</h2>
  <p>In your view file, simply call <code>flashdata()</code> with no arguments to display the message with default formatting.</p>
- <pre><code>&lt;?php
-// In your view file
-flashdata();
-?&gt;</code></pre>
+ [code=php]flashdata();[/code]
  <p>This outputs something like <code>&lt;p style="color: green;"&gt;Record created successfully&lt;/p&gt;</code> if a message exists, or nothing if there is no message.</p>
 
  <h2>Example #2: Custom HTML Wrapping</h2>
  <p>Pass custom opening and closing HTML to match your application's design system.</p>
- <pre><code>&lt;?php
-flashdata([
-    'opening_html' => '&lt;div class="alert alert-success" role="alert"&gt;',
-    'closing_html' => '&lt;/div&gt;'
-]);
-?&gt;</code></pre>
+ [code=php]flashdata([
+    'opening_html' =&gt; '&lt;div class="alert alert-success" role="alert"&gt;',
+    'closing_html' =&gt; '&lt;/div&gt;'
+]);[/code]
 
  <h2>Example #3: Using Global Defaults via Config Constants</h2>
  <p>Define <code>FLASHDATA_OPEN</code> and <code>FLASHDATA_CLOSE</code> in your <code>config/config.php</code> file to set a global default style for all flash messages across your application.</p>
- <pre><code>&lt;?php
-// In config/config.php
+ [code=php]// In config/config.php
 define('FLASHDATA_OPEN', '&lt;div class="toast toast-success"&gt;');
-define('FLASHDATA_CLOSE', '&lt;/div&gt;');
-?&gt;</code></pre>
+define('FLASHDATA_CLOSE', '&lt;/div&gt;');[/code]
  <p>With these constants defined, calls to <code>flashdata()</code> with no arguments will automatically use your custom wrapping.</p>
 
  <h2>Example #4: Using the Module Directly</h2>
  <p>For explicit routing, call the module method via <code>Modules::run()</code>. This is equivalent to the helper function but gives you direct access to the module method.</p>
- <pre><code>&lt;?php
-$message = Modules::run('flashdata/flashdata', [
-    'opening_html' => '&lt;div class="custom-notification"&gt;',
-    'closing_html' => '&lt;/div&gt;'
+ [code=php]$message = Modules::run('flashdata/flashdata', [
+    'opening_html' =&gt; '&lt;div class="custom-notification"&gt;',
+    'closing_html' =&gt; '&lt;/div&gt;'
 ]);
 
 if ($message !== null) {
     echo $message;
-}
-?&gt;</code></pre>
+}[/code]
 
  <h2>Notes</h2>
  <ul>

--- a/assets/reference/included/flashdata/manifest.php
+++ b/assets/reference/included/flashdata/manifest.php
@@ -1,0 +1,7 @@
+<?php
+return [
+    'url_string' => 'flashdata-module',
+    'headline' => 'The Flashdata Module',
+    'description' => 'The Flashdata Module provides one-time session messages, commonly used for success and error notifications after form submissions and redirects.',
+    'info' => '<p class="container-xs">The Flashdata Module implements a "set it and forget it" pattern for temporary session messages. Messages are stored in the session with <code>set_flashdata()</code>, survive a redirect, and are automatically cleared after being retrieved with <code>flashdata()</code>. This ensures each notification is displayed exactly once to the user.</p><p class="container-xs">The module supports custom HTML wrapping via <code>\'opening_html\'</code> and <code>\'closing_html\'</code> parameters, global defaults via the <code>FLASHDATA_OPEN</code> and <code>FLASHDATA_CLOSE</code> config constants, and a built-in green <code>&lt;p&gt;</code> tag fallback.</p>'
+];

--- a/assets/reference/included/flashdata/set_flashdata.html
+++ b/assets/reference/included/flashdata/set_flashdata.html
@@ -1,0 +1,89 @@
+<div class="container">
+ <h1>set_flashdata()</h1>
+ <p class="signature">public function set_flashdata(string $msg): void</p>
+
+ <h2>Description</h2>
+ <div class="description">
+ <p>
+ Stores a one-time flash message into the session. This is the "set" half of the flashdata pattern — you call this method before a redirect, and the message persists in the session until it is retrieved by <code>flashdata()</code> on the next page load.
+ </p>
+ <p>
+ The method handles the following behaviour:
+ </p>
+ <ul>
+ <li>The message is stored in <code>$_SESSION['flashdata']</code> as a plain string.</li>
+ <li>Only one flash message can be stored at a time — a subsequent call overwrites any existing message.</li>
+ <li>The message persists across a single redirect and is automatically cleared once retrieved.</li>
+ <li>If the user refreshes the page without calling <code>flashdata()</code>, the message persists in the session.</li>
+ </ul>
+ </div>
+
+ <h2>Parameters</h2>
+ <table class="params-table">
+ <thead>
+ <tr>
+ <th>Parameter</th>
+ <th>Type</th>
+ <th>Description</th>
+ <th>Default</th>
+ <th>Required</th>
+ </tr>
+ </thead>
+ <tbody>
+ <tr>
+ <td><code>$msg</code></td>
+ <td>string</td>
+ <td>The message text to store. This is typically a human-readable notification such as <code>'Record created successfully'</code> or <code>'Changes saved'</code>. The string is stored as-is without any escaping or transformation.</td>
+ <td>N/A</td>
+ <td><strong>Yes</strong></td>
+ </tr>
+ </tbody>
+ </table>
+
+ <h2>Return Value</h2>
+ <table>
+ <thead>
+ <tr>
+ <th>Type</th>
+ <th>Description</th>
+ </tr>
+ </thead>
+ <tbody>
+ <tr>
+ <td>void</td>
+ <td>This method does not return a value. It stores the message directly in the PHP session.</td>
+ </tr>
+ </tbody>
+ </table>
+
+ <h2>Example #1: Basic Usage with Helper Function</h2>
+ <p>The most common pattern is to call <code>set_flashdata()</code> after a successful form submission, then redirect to another page where the message will be displayed.</p>
+ <pre><code>&lt;?php
+public function submit(): void {
+    $this->trongate_security->make_sure_allowed();
+
+    if (post('submit', true) === 'Submit') {
+        $data = $this->model->get_post_data_for_database();
+        $this->model->create_new_record($data);
+        // highlight-next-line
+        set_flashdata('Record created successfully');
+        redirect('tasks/manage');
+    }
+}
+?&gt;</code></pre>
+
+ <h2>Example #2: Using the Module Directly</h2>
+ <p>You may also call the module method directly via <code>Modules::run()</code> if you prefer explicit routing.</p>
+ <pre><code>&lt;?php
+Modules::run('flashdata/set_flashdata', 'Your changes have been saved');
+?&gt;</code></pre>
+
+ <h2>Notes</h2>
+ <ul>
+ <li><strong>One at a time:</strong> Only a single flash message can be stored. A second call overwrites the first.</li>
+ <li><strong>Redirect-friendly:</strong> Flashdata survives redirects because it is stored in the session, not in request data.</li>
+ <li><strong>No formatting:</strong> The message is stored as plain text. Use the <code>flashdata()</code> method or helper to apply HTML wrapping when displaying.</li>
+ <li><strong>Race condition awareness:</strong> If <code>set_flashdata()</code> is called but <code>flashdata()</code> is never called on the next page load, the message will remain in the session until the next call to <code>flashdata()</code> retrieves it.</li>
+ </ul>
+
+</div>

--- a/assets/reference/included/flashdata/set_flashdata.html
+++ b/assets/reference/included/flashdata/set_flashdata.html
@@ -58,25 +58,20 @@
 
  <h2>Example #1: Basic Usage with Helper Function</h2>
  <p>The most common pattern is to call <code>set_flashdata()</code> after a successful form submission, then redirect to another page where the message will be displayed.</p>
- <pre><code>&lt;?php
-public function submit(): void {
-    $this->trongate_security->make_sure_allowed();
+ [code=php]public function submit(): void {
+    $this-&gt;trongate_security-&gt;make_sure_allowed();
 
     if (post('submit', true) === 'Submit') {
-        $data = $this->model->get_post_data_for_database();
-        $this->model->create_new_record($data);
-        // highlight-next-line
+        $data = $this-&gt;model-&gt;get_post_data_for_database();
+        $this-&gt;model-&gt;create_new_record($data);
         set_flashdata('Record created successfully');
         redirect('tasks/manage');
     }
-}
-?&gt;</code></pre>
+}[/code]
 
  <h2>Example #2: Using the Module Directly</h2>
  <p>You may also call the module method directly via <code>Modules::run()</code> if you prefer explicit routing.</p>
- <pre><code>&lt;?php
-Modules::run('flashdata/set_flashdata', 'Your changes have been saved');
-?&gt;</code></pre>
+ [code=php]Modules::run('flashdata/set_flashdata', 'Your changes have been saved');[/code]
 
  <h2>Notes</h2>
  <ul>


### PR DESCRIPTION
## Summary

Creates the **flashdata** module reference directory under `assets/reference/included/`, documenting both public methods from the validacious framework source code.

### Changes

**Added:**
- `assets/reference/included/flashdata/manifest.php` — Module metadata
- `assets/reference/included/flashdata/set_flashdata.html` — Stores a one-time flash message in the session
- `assets/reference/included/flashdata/flashdata.html` — Retrieves and formats the flash message with configurable HTML wrapping

### Examples include:
- Controller usage with `set_flashdata()` after form submission
- View usage with the `flashdata()` helper
- Custom HTML wrapping for application-specific styling
- Global default configuration via `FLASHDATA_OPEN` / `FLASHDATA_CLOSE` config constants
- Direct module invocation via `Modules::run()`

### Notes
- Follows the same format as the pagination reference page review in PR #49
- Uses `<pre><code>` blocks with proper HTML entity encoding