### PR TITLE
Simplify module method pages with helper function links

### DIFF
--- a/assets/reference/included/form/form_button.html
+++ b/assets/reference/included/form/form_button.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>form_button()</h1>
- <p class="signature">public function form_button(array $data): string </p>
-
- <h2>Description</h2>
- <p>Content pending for form/form_button.</p>
-
+ <p class="signature">public function form_button(array $data): string</p>
+ <div class="alert alert-info">
+ <p>The <code>form_button()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/form-helpers/form-button">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/form/form_checkbox.html
+++ b/assets/reference/included/form/form_checkbox.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>form_checkbox()</h1>
- <p class="signature">public function form_checkbox(array $data): string </p>
-
- <h2>Description</h2>
- <p>Content pending for form/form_checkbox.</p>
-
+ <p class="signature">public function form_checkbox(array $data): string</p>
+ <div class="alert alert-info">
+ <p>The <code>form_checkbox()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/form-helpers/form-checkbox">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/form/form_close.html
+++ b/assets/reference/included/form/form_close.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>form_close()</h1>
- <p class="signature">public function form_close(): string </p>
-
- <h2>Description</h2>
- <p>Content pending for form/form_close.</p>
-
+ <p class="signature">public function form_close(): string</p>
+ <div class="alert alert-info">
+ <p>The <code>form_close()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/form-helpers/form-close">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/form/form_date.html
+++ b/assets/reference/included/form/form_date.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>form_date()</h1>
- <p class="signature">public function form_date(array $attributes = []): string </p>
-
- <h2>Description</h2>
- <p>Content pending for form/form_date.</p>
-
+ <p class="signature">public function form_date(array $attributes = []): string</p>
+ <div class="alert alert-info">
+ <p>The <code>form_date()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/form-helpers/form-date">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/form/form_datetime_local.html
+++ b/assets/reference/included/form/form_datetime_local.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>form_datetime_local()</h1>
- <p class="signature">public function form_datetime_local(array $attributes = []): string </p>
-
- <h2>Description</h2>
- <p>Content pending for form/form_datetime_local.</p>
-
+ <p class="signature">public function form_datetime_local(array $attributes = []): string</p>
+ <div class="alert alert-info">
+ <p>The <code>form_datetime_local()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/form-helpers/form-datetime-local">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/form/form_dropdown.html
+++ b/assets/reference/included/form/form_dropdown.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>form_dropdown()</h1>
- <p class="signature">public function form_dropdown(array $data): string </p>
-
- <h2>Description</h2>
- <p>Content pending for form/form_dropdown.</p>
-
+ <p class="signature">public function form_dropdown(array $data): string</p>
+ <div class="alert alert-info">
+ <p>The <code>form_dropdown()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/form-helpers/form-dropdown">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/form/form_email.html
+++ b/assets/reference/included/form/form_email.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>form_email()</h1>
- <p class="signature">public function form_email(array $attributes = []): string </p>
-
- <h2>Description</h2>
- <p>Content pending for form/form_email.</p>
-
+ <p class="signature">public function form_email(array $attributes = []): string</p>
+ <div class="alert alert-info">
+ <p>The <code>form_email()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/form-helpers/form-email">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/form/form_file_select.html
+++ b/assets/reference/included/form/form_file_select.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>form_file_select()</h1>
- <p class="signature">public function form_file_select(array $attributes = []): string </p>
-
- <h2>Description</h2>
- <p>Content pending for form/form_file_select.</p>
-
+ <p class="signature">public function form_file_select(array $attributes = []): string</p>
+ <div class="alert alert-info">
+ <p>The <code>form_file_select()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/form-helpers/form-file-select">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/form/form_hidden.html
+++ b/assets/reference/included/form/form_hidden.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>form_hidden()</h1>
- <p class="signature">public function form_hidden(array $data): string </p>
-
- <h2>Description</h2>
- <p>Content pending for form/form_hidden.</p>
-
+ <p class="signature">public function form_hidden(array $data): string</p>
+ <div class="alert alert-info">
+ <p>The <code>form_hidden()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/form-helpers/form-hidden">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/form/form_input.html
+++ b/assets/reference/included/form/form_input.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>form_input()</h1>
- <p class="signature">public function form_input(array $attributes = []): string </p>
-
- <h2>Description</h2>
- <p>Content pending for form/form_input.</p>
-
+ <p class="signature">public function form_input(array $attributes = []): string</p>
+ <div class="alert alert-info">
+ <p>The <code>form_input()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/form-helpers/form-input">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/form/form_label.html
+++ b/assets/reference/included/form/form_label.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>form_label()</h1>
- <p class="signature">public function form_label(array $data): string </p>
-
- <h2>Description</h2>
- <p>Content pending for form/form_label.</p>
-
+ <p class="signature">public function form_label(array $data): string</p>
+ <div class="alert alert-info">
+ <p>The <code>form_label()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/form-helpers/form-label">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/form/form_month.html
+++ b/assets/reference/included/form/form_month.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>form_month()</h1>
- <p class="signature">public function form_month(array $attributes = []): string </p>
-
- <h2>Description</h2>
- <p>Content pending for form/form_month.</p>
-
+ <p class="signature">public function form_month(array $attributes = []): string</p>
+ <div class="alert alert-info">
+ <p>The <code>form_month()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/form-helpers/form-month">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/form/form_number.html
+++ b/assets/reference/included/form/form_number.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>form_number()</h1>
- <p class="signature">public function form_number(array $attributes = []): string </p>
-
- <h2>Description</h2>
- <p>Content pending for form/form_number.</p>
-
+ <p class="signature">public function form_number(array $attributes = []): string</p>
+ <div class="alert alert-info">
+ <p>The <code>form_number()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/form-helpers/form-number">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/form/form_open.html
+++ b/assets/reference/included/form/form_open.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>form_open()</h1>
- <p class="signature">public function form_open(array $data): string </p>
-
- <h2>Description</h2>
- <p>Content pending for form/form_open.</p>
-
+ <p class="signature">public function form_open(array $data): string</p>
+ <div class="alert alert-info">
+ <p>The <code>form_open()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/form-helpers/form-open">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/form/form_open_upload.html
+++ b/assets/reference/included/form/form_open_upload.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>form_open_upload()</h1>
- <p class="signature">public function form_open_upload(array $data): string </p>
-
- <h2>Description</h2>
- <p>Content pending for form/form_open_upload.</p>
-
+ <p class="signature">public function form_open_upload(array $data): string</p>
+ <div class="alert alert-info">
+ <p>The <code>form_open_upload()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/form-helpers/form-open-upload">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/form/form_password.html
+++ b/assets/reference/included/form/form_password.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>form_password()</h1>
- <p class="signature">public function form_password(array $attributes = []): string </p>
-
- <h2>Description</h2>
- <p>Content pending for form/form_password.</p>
-
+ <p class="signature">public function form_password(array $attributes = []): string</p>
+ <div class="alert alert-info">
+ <p>The <code>form_password()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/form-helpers/form-password">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/form/form_radio.html
+++ b/assets/reference/included/form/form_radio.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>form_radio()</h1>
- <p class="signature">public function form_radio(array $data): string </p>
-
- <h2>Description</h2>
- <p>Content pending for form/form_radio.</p>
-
+ <p class="signature">public function form_radio(array $data): string</p>
+ <div class="alert alert-info">
+ <p>The <code>form_radio()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/form-helpers/form-radio">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/form/form_search.html
+++ b/assets/reference/included/form/form_search.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>form_search()</h1>
- <p class="signature">public function form_search(array $attributes = []): string </p>
-
- <h2>Description</h2>
- <p>Content pending for form/form_search.</p>
-
+ <p class="signature">public function form_search(array $attributes = []): string</p>
+ <div class="alert alert-info">
+ <p>The <code>form_search()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/form-helpers/form-search">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/form/form_submit.html
+++ b/assets/reference/included/form/form_submit.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>form_submit()</h1>
- <p class="signature">public function form_submit(array $data): string </p>
-
- <h2>Description</h2>
- <p>Content pending for form/form_submit.</p>
-
+ <p class="signature">public function form_submit(array $data): string</p>
+ <div class="alert alert-info">
+ <p>The <code>form_submit()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/form-helpers/form-submit">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/form/form_textarea.html
+++ b/assets/reference/included/form/form_textarea.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>form_textarea()</h1>
- <p class="signature">public function form_textarea(array $attributes = []): string </p>
-
- <h2>Description</h2>
- <p>Content pending for form/form_textarea.</p>
-
+ <p class="signature">public function form_textarea(array $attributes = []): string</p>
+ <div class="alert alert-info">
+ <p>The <code>form_textarea()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/form-helpers/form-textarea">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/form/form_time.html
+++ b/assets/reference/included/form/form_time.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>form_time()</h1>
- <p class="signature">public function form_time(array $attributes = []): string </p>
-
- <h2>Description</h2>
- <p>Content pending for form/form_time.</p>
-
+ <p class="signature">public function form_time(array $attributes = []): string</p>
+ <div class="alert alert-info">
+ <p>The <code>form_time()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/form-helpers/form-time">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/form/form_week.html
+++ b/assets/reference/included/form/form_week.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>form_week()</h1>
- <p class="signature">public function form_week(array $attributes = []): string </p>
-
- <h2>Description</h2>
- <p>Content pending for form/form_week.</p>
-
+ <p class="signature">public function form_week(array $attributes = []): string</p>
+ <div class="alert alert-info">
+ <p>The <code>form_week()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/form-helpers/form-week">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/form/generate_input_element.html
+++ b/assets/reference/included/form/generate_input_element.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>generate_input_element()</h1>
- <p class="signature">public function generate_input_element(array $data): string </p>
-
- <h2>Description</h2>
- <p>Content pending for form/generate_input_element.</p>
-
+ <p class="signature">public function generate_input_element(array $data): string</p>
+ <div class="alert alert-info">
+ <p>The <code>generate_input_element()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/form-helpers/generate-input-element">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/form/get_attributes_str.html
+++ b/assets/reference/included/form/get_attributes_str.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>get_attributes_str()</h1>
- <p class="signature">public function get_attributes_str(array $attributes = []): string </p>
-
- <h2>Description</h2>
- <p>Content pending for form/get_attributes_str.</p>
-
+ <p class="signature">public function get_attributes_str(array $attributes = []): string</p>
+ <div class="alert alert-info">
+ <p>The <code>get_attributes_str()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/form-helpers/get-attributes-str">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/form/post.html
+++ b/assets/reference/included/form/post.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>post()</h1>
  <p class="signature">public function post(array $data): string|int|float|array</p>
-
- <h2>Description</h2>
- <p>Content pending for form/post.</p>
-
+ <div class="alert alert-info">
+ <p>The <code>post()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/form-helpers/post">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/string_service/extract_content.html
+++ b/assets/reference/included/string_service/extract_content.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>extract_content()</h1>
- <p class="signature">public function extract_content(array $data): string </p>
-
- <h2>Description</h2>
- <p>Content pending for string_service/extract_content.</p>
-
+ <p class="signature">public function extract_content(array $data): string</p>
+ <div class="alert alert-info">
+ <p>The <code>extract_content()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/string-helpers/extract-content">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/string_service/filter_name.html
+++ b/assets/reference/included/string_service/filter_name.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>filter_name()</h1>
- <p class="signature">public function filter_name(array $data): string </p>
-
- <h2>Description</h2>
- <p>Content pending for string_service/filter_name.</p>
-
+ <p class="signature">public function filter_name(array $data): string</p>
+ <div class="alert alert-info">
+ <p>The <code>filter_name()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/string-helpers/filter-name">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/string_service/filter_str.html
+++ b/assets/reference/included/string_service/filter_str.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>filter_str()</h1>
- <p class="signature">public function filter_str(array $data): string </p>
-
- <h2>Description</h2>
- <p>Content pending for string_service/filter_str.</p>
-
+ <p class="signature">public function filter_str(array $data): string</p>
+ <div class="alert alert-info">
+ <p>The <code>filter_str()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/string-helpers/filter-str">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/string_service/filter_string.html
+++ b/assets/reference/included/string_service/filter_string.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>filter_string()</h1>
- <p class="signature">public function filter_string(array $data): string </p>
-
- <h2>Description</h2>
- <p>Content pending for string_service/filter_string.</p>
-
+ <p class="signature">public function filter_string(array $data): string</p>
+ <div class="alert alert-info">
+ <p>The <code>filter_string()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/string-helpers/filter-string">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/string_service/get_last_part.html
+++ b/assets/reference/included/string_service/get_last_part.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>get_last_part()</h1>
- <p class="signature">public function get_last_part(array $data): string </p>
-
- <h2>Description</h2>
- <p>Content pending for string_service/get_last_part.</p>
-
+ <p class="signature">public function get_last_part(array $data): string</p>
+ <div class="alert alert-info">
+ <p>The <code>get_last_part()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/string-helpers/get-last-part">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/string_service/make_rand_str.html
+++ b/assets/reference/included/string_service/make_rand_str.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>make_rand_str()</h1>
- <p class="signature">public function make_rand_str(array $data): string </p>
-
- <h2>Description</h2>
- <p>Content pending for string_service/make_rand_str.</p>
-
+ <p class="signature">public function make_rand_str(array $data): string</p>
+ <div class="alert alert-info">
+ <p>The <code>make_rand_str()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/string-helpers/make-rand-str">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/string_service/nice_price.html
+++ b/assets/reference/included/string_service/nice_price.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>nice_price()</h1>
- <p class="signature">public function nice_price(array $data): string </p>
-
- <h2>Description</h2>
- <p>Content pending for string_service/nice_price.</p>
-
+ <p class="signature">public function nice_price(array $data): string</p>
+ <div class="alert alert-info">
+ <p>The <code>nice_price()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/string-helpers/nice-price">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/string_service/out.html
+++ b/assets/reference/included/string_service/out.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>out()</h1>
- <p class="signature">public function out(array $data): string </p>
-
- <h2>Description</h2>
- <p>Content pending for string_service/out.</p>
-
+ <p class="signature">public function out(array $data): string</p>
+ <div class="alert alert-info">
+ <p>The <code>out()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/string-helpers/out">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/string_service/remove_html_code.html
+++ b/assets/reference/included/string_service/remove_html_code.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>remove_html_code()</h1>
- <p class="signature">public function remove_html_code(array $data): string </p>
-
- <h2>Description</h2>
- <p>Content pending for string_service/remove_html_code.</p>
-
+ <p class="signature">public function remove_html_code(array $data): string</p>
+ <div class="alert alert-info">
+ <p>The <code>remove_html_code()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/string-helpers/remove-html-code">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/string_service/remove_substr_between.html
+++ b/assets/reference/included/string_service/remove_substr_between.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>remove_substr_between()</h1>
- <p class="signature">public function remove_substr_between(array $data): string </p>
-
- <h2>Description</h2>
- <p>Content pending for string_service/remove_substr_between.</p>
-
+ <p class="signature">public function remove_substr_between(array $data): string</p>
+ <div class="alert alert-info">
+ <p>The <code>remove_substr_between()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/string-helpers/remove-substr-between">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/string_service/replace_html_tags.html
+++ b/assets/reference/included/string_service/replace_html_tags.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>replace_html_tags()</h1>
- <p class="signature">public function replace_html_tags(array $data): string </p>
-
- <h2>Description</h2>
- <p>Content pending for string_service/replace_html_tags.</p>
-
+ <p class="signature">public function replace_html_tags(array $data): string</p>
+ <div class="alert alert-info">
+ <p>The <code>replace_html_tags()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/string-helpers/replace-html-tags">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/string_service/sanitize_filename.html
+++ b/assets/reference/included/string_service/sanitize_filename.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>sanitize_filename()</h1>
- <p class="signature">public function sanitize_filename(array $data): string </p>
-
- <h2>Description</h2>
- <p>Content pending for string_service/sanitize_filename.</p>
-
+ <p class="signature">public function sanitize_filename(array $data): string</p>
+ <div class="alert alert-info">
+ <p>The <code>sanitize_filename()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/string-helpers/sanitize-filename">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/string_service/truncate_str.html
+++ b/assets/reference/included/string_service/truncate_str.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>truncate_str()</h1>
- <p class="signature">public function truncate_str(array $data): string </p>
-
- <h2>Description</h2>
- <p>Content pending for string_service/truncate_str.</p>
-
+ <p class="signature">public function truncate_str(array $data): string</p>
+ <div class="alert alert-info">
+ <p>The <code>truncate_str()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/string-helpers/truncate-str">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/string_service/truncate_words.html
+++ b/assets/reference/included/string_service/truncate_words.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>truncate_words()</h1>
- <p class="signature">public function truncate_words(array $data): string </p>
-
- <h2>Description</h2>
- <p>Content pending for string_service/truncate_words.</p>
-
+ <p class="signature">public function truncate_words(array $data): string</p>
+ <div class="alert alert-info">
+ <p>The <code>truncate_words()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/string-helpers/truncate-words">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/string_service/url_title.html
+++ b/assets/reference/included/string_service/url_title.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>url_title()</h1>
- <p class="signature">public function url_title(array $data): string </p>
-
- <h2>Description</h2>
- <p>Content pending for string_service/url_title.</p>
-
+ <p class="signature">public function url_title(array $data): string</p>
+ <div class="alert alert-info">
+ <p>The <code>url_title()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/string-helpers/url-title">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/url/anchor.html
+++ b/assets/reference/included/url/anchor.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>anchor()</h1>
- <p class="signature">public function anchor(array $data = []): string </p>
-
- <h2>Description</h2>
- <p>Content pending for url/anchor.</p>
-
+ <p class="signature">public function anchor(array $data = []): string</p>
+ <div class="alert alert-info">
+ <p>The <code>anchor()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/url-helpers/anchor">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/url/current_url.html
+++ b/assets/reference/included/url/current_url.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>current_url()</h1>
- <p class="signature">public function current_url(): string </p>
-
- <h2>Description</h2>
- <p>Content pending for url/current_url.</p>
-
+ <p class="signature">public function current_url(): string</p>
+ <div class="alert alert-info">
+ <p>The <code>current_url()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/url-helpers/current-url">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/url/get_last_segment.html
+++ b/assets/reference/included/url/get_last_segment.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>get_last_segment()</h1>
- <p class="signature">public function get_last_segment(): string </p>
-
- <h2>Description</h2>
- <p>Content pending for url/get_last_segment.</p>
-
+ <p class="signature">public function get_last_segment(): string</p>
+ <div class="alert alert-info">
+ <p>The <code>get_last_segment()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/url-helpers/get-last-segment">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/url/previous_url.html
+++ b/assets/reference/included/url/previous_url.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>previous_url()</h1>
- <p class="signature">public function previous_url(): string </p>
-
- <h2>Description</h2>
- <p>Content pending for url/previous_url.</p>
-
+ <p class="signature">public function previous_url(): string</p>
+ <div class="alert alert-info">
+ <p>The <code>previous_url()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/url-helpers/previous-url">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/url/redirect.html
+++ b/assets/reference/included/url/redirect.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>redirect()</h1>
- <p class="signature">public function redirect(string $target_url): void </p>
-
- <h2>Description</h2>
- <p>Content pending for url/redirect.</p>
-
+ <p class="signature">public function redirect(string $target_url): void</p>
+ <div class="alert alert-info">
+ <p>The <code>redirect()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/url-helpers/redirect">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/url/remove_query_string.html
+++ b/assets/reference/included/url/remove_query_string.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>remove_query_string()</h1>
- <p class="signature">public function remove_query_string(string $string): string </p>
-
- <h2>Description</h2>
- <p>Content pending for url/remove_query_string.</p>
-
+ <p class="signature">public function remove_query_string(string $string): string</p>
+ <div class="alert alert-info">
+ <p>The <code>remove_query_string()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/url-helpers/remove-query-string">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/url/segment.html
+++ b/assets/reference/included/url/segment.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>segment()</h1>
- <p class="signature">public function segment(array $data = []): mixed </p>
-
- <h2>Description</h2>
- <p>Content pending for url/segment.</p>
-
+ <p class="signature">public function segment(array $data = []): mixed</p>
+ <div class="alert alert-info">
+ <p>The <code>segment()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/url-helpers/segment">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/utilities/block_url.html
+++ b/assets/reference/included/utilities/block_url.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>block_url()</h1>
- <p class="signature">public function block_url(string $block_path = ''): void </p>
-
- <h2>Description</h2>
- <p>Content pending for utilities/block_url.</p>
-
+ <p class="signature">public function block_url(string $block_path = ''): void</p>
+ <div class="alert alert-info">
+ <p>The <code>block_url()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/utilities-helpers/block-url">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/utilities/display.html
+++ b/assets/reference/included/utilities/display.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>display()</h1>
- <p class="signature">public function display(array $data): void </p>
-
- <h2>Description</h2>
- <p>Content pending for utilities/display.</p>
-
+ <p class="signature">public function display(array $data): void</p>
+ <div class="alert alert-info">
+ <p>The <code>display()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/utilities-helpers/display">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/utilities/from_trongate_mx.html
+++ b/assets/reference/included/utilities/from_trongate_mx.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>from_trongate_mx()</h1>
- <p class="signature">public function from_trongate_mx(): bool </p>
-
- <h2>Description</h2>
- <p>Content pending for utilities/from_trongate_mx.</p>
-
+ <p class="signature">public function from_trongate_mx(): bool</p>
+ <div class="alert alert-info">
+ <p>The <code>from_trongate_mx()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/utilities-helpers/from-trongate-mx">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/utilities/ip_address.html
+++ b/assets/reference/included/utilities/ip_address.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>ip_address()</h1>
- <p class="signature">public function ip_address(): string </p>
-
- <h2>Description</h2>
- <p>Content pending for utilities/ip_address.</p>
-
+ <p class="signature">public function ip_address(): string</p>
+ <div class="alert alert-info">
+ <p>The <code>ip_address()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/utilities-helpers/ip-address">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/utilities/json.html
+++ b/assets/reference/included/utilities/json.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>json()</h1>
- <p class="signature">public function json(array $data): void </p>
-
- <h2>Description</h2>
- <p>Content pending for utilities/json.</p>
-
+ <p class="signature">public function json(array $data): void</p>
+ <div class="alert alert-info">
+ <p>The <code>json()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/utilities-helpers/json">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/utilities/return_file_info.html
+++ b/assets/reference/included/utilities/return_file_info.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>return_file_info()</h1>
- <p class="signature">public function return_file_info(string $file_string): array </p>
-
- <h2>Description</h2>
- <p>Content pending for utilities/return_file_info.</p>
-
+ <p class="signature">public function return_file_info(string $file_string): array</p>
+ <div class="alert alert-info">
+ <p>The <code>return_file_info()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/utilities-helpers/return-file-info">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/utilities/sort_by_property.html
+++ b/assets/reference/included/utilities/sort_by_property.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>sort_by_property()</h1>
- <p class="signature">public function sort_by_property(array $data): array </p>
-
- <h2>Description</h2>
- <p>Content pending for utilities/sort_by_property.</p>
-
+ <p class="signature">public function sort_by_property(array $data): array</p>
+ <div class="alert alert-info">
+ <p>The <code>sort_by_property()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/utilities-helpers/sort-by-property">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/utilities/sort_rows_by_property.html
+++ b/assets/reference/included/utilities/sort_rows_by_property.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>sort_rows_by_property()</h1>
- <p class="signature">public function sort_rows_by_property(array $data): array </p>
-
- <h2>Description</h2>
- <p>Content pending for utilities/sort_rows_by_property.</p>
-
+ <p class="signature">public function sort_rows_by_property(array $data): array</p>
+ <div class="alert alert-info">
+ <p>The <code>sort_rows_by_property()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/utilities-helpers/sort-rows-by-property">click here</a>.
+ </p>
+ </div>
 </div>


### PR DESCRIPTION
## Summary

Converts 55 module method stub pages to the simplified format for modules that have corresponding helper functions.

### Modules updated

| Module | Pages | Helper URL string |
|---|---|---|
| form | 24 | form-helpers |
| string_service | 15 | string-helpers |
| url | 7 | url-helpers |
| utilities | 8 | utilities-helpers |

### Format

Each page now contains:
- Method signature (extracted from existing stubs)
- Alert box with link to the dedicated helper page
- Link URL pattern: `documentation-ref/information/helpers/{url-string}/{method-name-with-hyphens}`

### Example

`form_open.html` links to `documentation-ref/information/helpers/form-helpers/form-open`

### Notes
- Flashdata method pages already updated with this format on main
- Modules without helper functions (db, file, image, etc.) left unchanged