### PR TITLE
Fix helper link URLs to use snake_case method names

### DIFF
--- a/assets/reference/included/flashdata/flashdata.html
+++ b/assets/reference/included/flashdata/flashdata.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>flashdata()</h1>
- <p class="signature">public function flashdata(array $data = []): ?string </p>
-
- <h2>Description</h2>
- <p>Content pending for flashdata/flashdata.</p>
-
+ <p class="signature">public function flashdata(array $data = []): ?string</p>
+ <div class="alert alert-info">
+ <p>The <code>flashdata()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/flashdata-helpers/flashdata">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/flashdata/set_flashdata.html
+++ b/assets/reference/included/flashdata/set_flashdata.html
@@ -1,8 +1,9 @@
 <div class="container">
  <h1>set_flashdata()</h1>
- <p class="signature">public function set_flashdata(string $msg): void </p>
-
- <h2>Description</h2>
- <p>Content pending for flashdata/set_flashdata.</p>
-
+ <p class="signature">public function set_flashdata(string $msg): void</p>
+ <div class="alert alert-info">
+ <p>The <code>set_flashdata()</code> method is supported by a dedicated helper function. For guidance on how to use it,
+ <a href="documentation-ref/information/helpers/flashdata-helpers/set_flashdata">click here</a>.
+ </p>
+ </div>
 </div>

--- a/assets/reference/included/form/form_button.html
+++ b/assets/reference/included/form/form_button.html
@@ -3,7 +3,7 @@
  <p class="signature">public function form_button(array $data): string</p>
  <div class="alert alert-info">
  <p>The <code>form_button()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/form-helpers/form-button">click here</a>.
+ <a href="documentation-ref/information/helpers/form-helpers/form_button">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/form/form_checkbox.html
+++ b/assets/reference/included/form/form_checkbox.html
@@ -3,7 +3,7 @@
  <p class="signature">public function form_checkbox(array $data): string</p>
  <div class="alert alert-info">
  <p>The <code>form_checkbox()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/form-helpers/form-checkbox">click here</a>.
+ <a href="documentation-ref/information/helpers/form-helpers/form_checkbox">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/form/form_close.html
+++ b/assets/reference/included/form/form_close.html
@@ -3,7 +3,7 @@
  <p class="signature">public function form_close(): string</p>
  <div class="alert alert-info">
  <p>The <code>form_close()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/form-helpers/form-close">click here</a>.
+ <a href="documentation-ref/information/helpers/form-helpers/form_close">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/form/form_date.html
+++ b/assets/reference/included/form/form_date.html
@@ -3,7 +3,7 @@
  <p class="signature">public function form_date(array $attributes = []): string</p>
  <div class="alert alert-info">
  <p>The <code>form_date()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/form-helpers/form-date">click here</a>.
+ <a href="documentation-ref/information/helpers/form-helpers/form_date">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/form/form_datetime_local.html
+++ b/assets/reference/included/form/form_datetime_local.html
@@ -3,7 +3,7 @@
  <p class="signature">public function form_datetime_local(array $attributes = []): string</p>
  <div class="alert alert-info">
  <p>The <code>form_datetime_local()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/form-helpers/form-datetime-local">click here</a>.
+ <a href="documentation-ref/information/helpers/form-helpers/form_datetime_local">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/form/form_dropdown.html
+++ b/assets/reference/included/form/form_dropdown.html
@@ -3,7 +3,7 @@
  <p class="signature">public function form_dropdown(array $data): string</p>
  <div class="alert alert-info">
  <p>The <code>form_dropdown()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/form-helpers/form-dropdown">click here</a>.
+ <a href="documentation-ref/information/helpers/form-helpers/form_dropdown">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/form/form_email.html
+++ b/assets/reference/included/form/form_email.html
@@ -3,7 +3,7 @@
  <p class="signature">public function form_email(array $attributes = []): string</p>
  <div class="alert alert-info">
  <p>The <code>form_email()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/form-helpers/form-email">click here</a>.
+ <a href="documentation-ref/information/helpers/form-helpers/form_email">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/form/form_file_select.html
+++ b/assets/reference/included/form/form_file_select.html
@@ -3,7 +3,7 @@
  <p class="signature">public function form_file_select(array $attributes = []): string</p>
  <div class="alert alert-info">
  <p>The <code>form_file_select()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/form-helpers/form-file-select">click here</a>.
+ <a href="documentation-ref/information/helpers/form-helpers/form_file_select">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/form/form_hidden.html
+++ b/assets/reference/included/form/form_hidden.html
@@ -3,7 +3,7 @@
  <p class="signature">public function form_hidden(array $data): string</p>
  <div class="alert alert-info">
  <p>The <code>form_hidden()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/form-helpers/form-hidden">click here</a>.
+ <a href="documentation-ref/information/helpers/form-helpers/form_hidden">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/form/form_input.html
+++ b/assets/reference/included/form/form_input.html
@@ -3,7 +3,7 @@
  <p class="signature">public function form_input(array $attributes = []): string</p>
  <div class="alert alert-info">
  <p>The <code>form_input()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/form-helpers/form-input">click here</a>.
+ <a href="documentation-ref/information/helpers/form-helpers/form_input">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/form/form_label.html
+++ b/assets/reference/included/form/form_label.html
@@ -3,7 +3,7 @@
  <p class="signature">public function form_label(array $data): string</p>
  <div class="alert alert-info">
  <p>The <code>form_label()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/form-helpers/form-label">click here</a>.
+ <a href="documentation-ref/information/helpers/form-helpers/form_label">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/form/form_month.html
+++ b/assets/reference/included/form/form_month.html
@@ -3,7 +3,7 @@
  <p class="signature">public function form_month(array $attributes = []): string</p>
  <div class="alert alert-info">
  <p>The <code>form_month()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/form-helpers/form-month">click here</a>.
+ <a href="documentation-ref/information/helpers/form-helpers/form_month">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/form/form_number.html
+++ b/assets/reference/included/form/form_number.html
@@ -3,7 +3,7 @@
  <p class="signature">public function form_number(array $attributes = []): string</p>
  <div class="alert alert-info">
  <p>The <code>form_number()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/form-helpers/form-number">click here</a>.
+ <a href="documentation-ref/information/helpers/form-helpers/form_number">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/form/form_open.html
+++ b/assets/reference/included/form/form_open.html
@@ -3,7 +3,7 @@
  <p class="signature">public function form_open(array $data): string</p>
  <div class="alert alert-info">
  <p>The <code>form_open()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/form-helpers/form-open">click here</a>.
+ <a href="documentation-ref/information/helpers/form-helpers/form_open">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/form/form_open_upload.html
+++ b/assets/reference/included/form/form_open_upload.html
@@ -3,7 +3,7 @@
  <p class="signature">public function form_open_upload(array $data): string</p>
  <div class="alert alert-info">
  <p>The <code>form_open_upload()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/form-helpers/form-open-upload">click here</a>.
+ <a href="documentation-ref/information/helpers/form-helpers/form_open_upload">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/form/form_password.html
+++ b/assets/reference/included/form/form_password.html
@@ -3,7 +3,7 @@
  <p class="signature">public function form_password(array $attributes = []): string</p>
  <div class="alert alert-info">
  <p>The <code>form_password()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/form-helpers/form-password">click here</a>.
+ <a href="documentation-ref/information/helpers/form-helpers/form_password">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/form/form_radio.html
+++ b/assets/reference/included/form/form_radio.html
@@ -3,7 +3,7 @@
  <p class="signature">public function form_radio(array $data): string</p>
  <div class="alert alert-info">
  <p>The <code>form_radio()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/form-helpers/form-radio">click here</a>.
+ <a href="documentation-ref/information/helpers/form-helpers/form_radio">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/form/form_search.html
+++ b/assets/reference/included/form/form_search.html
@@ -3,7 +3,7 @@
  <p class="signature">public function form_search(array $attributes = []): string</p>
  <div class="alert alert-info">
  <p>The <code>form_search()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/form-helpers/form-search">click here</a>.
+ <a href="documentation-ref/information/helpers/form-helpers/form_search">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/form/form_submit.html
+++ b/assets/reference/included/form/form_submit.html
@@ -3,7 +3,7 @@
  <p class="signature">public function form_submit(array $data): string</p>
  <div class="alert alert-info">
  <p>The <code>form_submit()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/form-helpers/form-submit">click here</a>.
+ <a href="documentation-ref/information/helpers/form-helpers/form_submit">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/form/form_textarea.html
+++ b/assets/reference/included/form/form_textarea.html
@@ -3,7 +3,7 @@
  <p class="signature">public function form_textarea(array $attributes = []): string</p>
  <div class="alert alert-info">
  <p>The <code>form_textarea()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/form-helpers/form-textarea">click here</a>.
+ <a href="documentation-ref/information/helpers/form-helpers/form_textarea">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/form/form_time.html
+++ b/assets/reference/included/form/form_time.html
@@ -3,7 +3,7 @@
  <p class="signature">public function form_time(array $attributes = []): string</p>
  <div class="alert alert-info">
  <p>The <code>form_time()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/form-helpers/form-time">click here</a>.
+ <a href="documentation-ref/information/helpers/form-helpers/form_time">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/form/form_week.html
+++ b/assets/reference/included/form/form_week.html
@@ -3,7 +3,7 @@
  <p class="signature">public function form_week(array $attributes = []): string</p>
  <div class="alert alert-info">
  <p>The <code>form_week()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/form-helpers/form-week">click here</a>.
+ <a href="documentation-ref/information/helpers/form-helpers/form_week">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/form/generate_input_element.html
+++ b/assets/reference/included/form/generate_input_element.html
@@ -3,7 +3,7 @@
  <p class="signature">public function generate_input_element(array $data): string</p>
  <div class="alert alert-info">
  <p>The <code>generate_input_element()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/form-helpers/generate-input-element">click here</a>.
+ <a href="documentation-ref/information/helpers/form-helpers/generate_input_element">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/form/get_attributes_str.html
+++ b/assets/reference/included/form/get_attributes_str.html
@@ -3,7 +3,7 @@
  <p class="signature">public function get_attributes_str(array $attributes = []): string</p>
  <div class="alert alert-info">
  <p>The <code>get_attributes_str()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/form-helpers/get-attributes-str">click here</a>.
+ <a href="documentation-ref/information/helpers/form-helpers/get_attributes_str">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/string_service/extract_content.html
+++ b/assets/reference/included/string_service/extract_content.html
@@ -3,7 +3,7 @@
  <p class="signature">public function extract_content(array $data): string</p>
  <div class="alert alert-info">
  <p>The <code>extract_content()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/string-helpers/extract-content">click here</a>.
+ <a href="documentation-ref/information/helpers/string-helpers/extract_content">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/string_service/filter_name.html
+++ b/assets/reference/included/string_service/filter_name.html
@@ -3,7 +3,7 @@
  <p class="signature">public function filter_name(array $data): string</p>
  <div class="alert alert-info">
  <p>The <code>filter_name()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/string-helpers/filter-name">click here</a>.
+ <a href="documentation-ref/information/helpers/string-helpers/filter_name">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/string_service/filter_str.html
+++ b/assets/reference/included/string_service/filter_str.html
@@ -3,7 +3,7 @@
  <p class="signature">public function filter_str(array $data): string</p>
  <div class="alert alert-info">
  <p>The <code>filter_str()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/string-helpers/filter-str">click here</a>.
+ <a href="documentation-ref/information/helpers/string-helpers/filter_str">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/string_service/filter_string.html
+++ b/assets/reference/included/string_service/filter_string.html
@@ -3,7 +3,7 @@
  <p class="signature">public function filter_string(array $data): string</p>
  <div class="alert alert-info">
  <p>The <code>filter_string()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/string-helpers/filter-string">click here</a>.
+ <a href="documentation-ref/information/helpers/string-helpers/filter_string">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/string_service/get_last_part.html
+++ b/assets/reference/included/string_service/get_last_part.html
@@ -3,7 +3,7 @@
  <p class="signature">public function get_last_part(array $data): string</p>
  <div class="alert alert-info">
  <p>The <code>get_last_part()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/string-helpers/get-last-part">click here</a>.
+ <a href="documentation-ref/information/helpers/string-helpers/get_last_part">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/string_service/make_rand_str.html
+++ b/assets/reference/included/string_service/make_rand_str.html
@@ -3,7 +3,7 @@
  <p class="signature">public function make_rand_str(array $data): string</p>
  <div class="alert alert-info">
  <p>The <code>make_rand_str()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/string-helpers/make-rand-str">click here</a>.
+ <a href="documentation-ref/information/helpers/string-helpers/make_rand_str">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/string_service/nice_price.html
+++ b/assets/reference/included/string_service/nice_price.html
@@ -3,7 +3,7 @@
  <p class="signature">public function nice_price(array $data): string</p>
  <div class="alert alert-info">
  <p>The <code>nice_price()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/string-helpers/nice-price">click here</a>.
+ <a href="documentation-ref/information/helpers/string-helpers/nice_price">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/string_service/remove_html_code.html
+++ b/assets/reference/included/string_service/remove_html_code.html
@@ -3,7 +3,7 @@
  <p class="signature">public function remove_html_code(array $data): string</p>
  <div class="alert alert-info">
  <p>The <code>remove_html_code()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/string-helpers/remove-html-code">click here</a>.
+ <a href="documentation-ref/information/helpers/string-helpers/remove_html_code">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/string_service/remove_substr_between.html
+++ b/assets/reference/included/string_service/remove_substr_between.html
@@ -3,7 +3,7 @@
  <p class="signature">public function remove_substr_between(array $data): string</p>
  <div class="alert alert-info">
  <p>The <code>remove_substr_between()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/string-helpers/remove-substr-between">click here</a>.
+ <a href="documentation-ref/information/helpers/string-helpers/remove_substr_between">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/string_service/replace_html_tags.html
+++ b/assets/reference/included/string_service/replace_html_tags.html
@@ -3,7 +3,7 @@
  <p class="signature">public function replace_html_tags(array $data): string</p>
  <div class="alert alert-info">
  <p>The <code>replace_html_tags()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/string-helpers/replace-html-tags">click here</a>.
+ <a href="documentation-ref/information/helpers/string-helpers/replace_html_tags">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/string_service/sanitize_filename.html
+++ b/assets/reference/included/string_service/sanitize_filename.html
@@ -3,7 +3,7 @@
  <p class="signature">public function sanitize_filename(array $data): string</p>
  <div class="alert alert-info">
  <p>The <code>sanitize_filename()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/string-helpers/sanitize-filename">click here</a>.
+ <a href="documentation-ref/information/helpers/string-helpers/sanitize_filename">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/string_service/truncate_str.html
+++ b/assets/reference/included/string_service/truncate_str.html
@@ -3,7 +3,7 @@
  <p class="signature">public function truncate_str(array $data): string</p>
  <div class="alert alert-info">
  <p>The <code>truncate_str()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/string-helpers/truncate-str">click here</a>.
+ <a href="documentation-ref/information/helpers/string-helpers/truncate_str">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/string_service/truncate_words.html
+++ b/assets/reference/included/string_service/truncate_words.html
@@ -3,7 +3,7 @@
  <p class="signature">public function truncate_words(array $data): string</p>
  <div class="alert alert-info">
  <p>The <code>truncate_words()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/string-helpers/truncate-words">click here</a>.
+ <a href="documentation-ref/information/helpers/string-helpers/truncate_words">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/string_service/url_title.html
+++ b/assets/reference/included/string_service/url_title.html
@@ -3,7 +3,7 @@
  <p class="signature">public function url_title(array $data): string</p>
  <div class="alert alert-info">
  <p>The <code>url_title()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/string-helpers/url-title">click here</a>.
+ <a href="documentation-ref/information/helpers/string-helpers/url_title">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/url/current_url.html
+++ b/assets/reference/included/url/current_url.html
@@ -3,7 +3,7 @@
  <p class="signature">public function current_url(): string</p>
  <div class="alert alert-info">
  <p>The <code>current_url()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/url-helpers/current-url">click here</a>.
+ <a href="documentation-ref/information/helpers/url-helpers/current_url">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/url/get_last_segment.html
+++ b/assets/reference/included/url/get_last_segment.html
@@ -3,7 +3,7 @@
  <p class="signature">public function get_last_segment(): string</p>
  <div class="alert alert-info">
  <p>The <code>get_last_segment()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/url-helpers/get-last-segment">click here</a>.
+ <a href="documentation-ref/information/helpers/url-helpers/get_last_segment">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/url/previous_url.html
+++ b/assets/reference/included/url/previous_url.html
@@ -3,7 +3,7 @@
  <p class="signature">public function previous_url(): string</p>
  <div class="alert alert-info">
  <p>The <code>previous_url()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/url-helpers/previous-url">click here</a>.
+ <a href="documentation-ref/information/helpers/url-helpers/previous_url">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/url/remove_query_string.html
+++ b/assets/reference/included/url/remove_query_string.html
@@ -3,7 +3,7 @@
  <p class="signature">public function remove_query_string(string $string): string</p>
  <div class="alert alert-info">
  <p>The <code>remove_query_string()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/url-helpers/remove-query-string">click here</a>.
+ <a href="documentation-ref/information/helpers/url-helpers/remove_query_string">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/utilities/block_url.html
+++ b/assets/reference/included/utilities/block_url.html
@@ -3,7 +3,7 @@
  <p class="signature">public function block_url(string $block_path = ''): void</p>
  <div class="alert alert-info">
  <p>The <code>block_url()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/utilities-helpers/block-url">click here</a>.
+ <a href="documentation-ref/information/helpers/utilities-helpers/block_url">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/utilities/from_trongate_mx.html
+++ b/assets/reference/included/utilities/from_trongate_mx.html
@@ -3,7 +3,7 @@
  <p class="signature">public function from_trongate_mx(): bool</p>
  <div class="alert alert-info">
  <p>The <code>from_trongate_mx()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/utilities-helpers/from-trongate-mx">click here</a>.
+ <a href="documentation-ref/information/helpers/utilities-helpers/from_trongate_mx">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/utilities/ip_address.html
+++ b/assets/reference/included/utilities/ip_address.html
@@ -3,7 +3,7 @@
  <p class="signature">public function ip_address(): string</p>
  <div class="alert alert-info">
  <p>The <code>ip_address()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/utilities-helpers/ip-address">click here</a>.
+ <a href="documentation-ref/information/helpers/utilities-helpers/ip_address">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/utilities/return_file_info.html
+++ b/assets/reference/included/utilities/return_file_info.html
@@ -3,7 +3,7 @@
  <p class="signature">public function return_file_info(string $file_string): array</p>
  <div class="alert alert-info">
  <p>The <code>return_file_info()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/utilities-helpers/return-file-info">click here</a>.
+ <a href="documentation-ref/information/helpers/utilities-helpers/return_file_info">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/utilities/sort_by_property.html
+++ b/assets/reference/included/utilities/sort_by_property.html
@@ -3,7 +3,7 @@
  <p class="signature">public function sort_by_property(array $data): array</p>
  <div class="alert alert-info">
  <p>The <code>sort_by_property()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/utilities-helpers/sort-by-property">click here</a>.
+ <a href="documentation-ref/information/helpers/utilities-helpers/sort_by_property">click here</a>.
  </p>
  </div>
 </div>

--- a/assets/reference/included/utilities/sort_rows_by_property.html
+++ b/assets/reference/included/utilities/sort_rows_by_property.html
@@ -3,7 +3,7 @@
  <p class="signature">public function sort_rows_by_property(array $data): array</p>
  <div class="alert alert-info">
  <p>The <code>sort_rows_by_property()</code> method is supported by a dedicated helper function. For guidance on how to use it,
- <a href="documentation-ref/information/helpers/utilities-helpers/sort-rows-by-property">click here</a>.
+ <a href="documentation-ref/information/helpers/utilities-helpers/sort_rows_by_property">click here</a>.
  </p>
  </div>
 </div>


### PR DESCRIPTION
## Summary

Fixes 48 helper link URLs that used hyphens instead of snake_case, and restores the simplified format for flashdata module pages.

### Changes

- **48 files** across form, string_service, url, utilities — corrected URL segments from hyphens to snake_case
- **2 flashdata module pages** — replaced 'Content pending' stubs with simplified format including helper function links

### Before (incorrect)
`documentation-ref/information/helpers/form-helpers/form-date`

### After (correct)
`documentation-ref/information/helpers/form-helpers/form_date`