### PR TITLE
Add URL helpers reference pages

### DIFF
--- a/assets/reference/helpers/url_helpers/anchor.html
+++ b/assets/reference/helpers/url_helpers/anchor.html
@@ -1,38 +1,39 @@
 <div class="container">
   <h1>anchor()</h1>
   <p class="signature">function anchor(string $url, ?string $text = null, array $attributes = []): string</p>
-  
   <h2>Description</h2>
   <div class="description">
-    <p>Generates an anchor (&lt;a&gt;) tag with optional attributes and partial XSS protection.</p> 
-    <p>This function creates an anchor tag pointing to a specified URL. If the <code>$text</code> parameter is omitted, the URL itself is used as the link text.</p> 
-
-    <p><strong>Important:</strong> The <code>$text</code> parameter is NOT escaped, allowing HTML content to be rendered as-is, while the URL and attributes are automatically escaped to prevent XSS attacks.</p>
+    <p>Generates an HTML anchor tag (<code>&lt;a&gt;</code>) with automatic base URL resolution and XSS protection. If the URL is relative (does not start with <code>http://</code>, <code>https://</code>, or <code>//</code>), the <code>BASE_URL</code> constant is prepended to ensure the link points to the correct internal route.</p>
+    <p>Attributes and URLs are automatically escaped to prevent XSS attacks.</p>
   </div>
   <h2>Parameters</h2>
   <table>
     <thead>
       <tr>
-        <th>Name</th>
+        <th>Parameter</th>
         <th>Type</th>
         <th>Description</th>
+        <th>Default</th>
       </tr>
     </thead>
     <tbody>
       <tr>
         <td>$url</td>
         <td>string</td>
-        <td>The URL to link to. This parameter is required and will be automatically escaped.</td>
+        <td>The destination URL. Can be relative or absolute.</td>
+        <td>N/A</td>
       </tr>
       <tr>
         <td>$text</td>
-        <td>string|null</td>
-        <td>The text content of the link (optional). If not provided, the URL itself is used. <strong>Note:</strong> This parameter is NOT escaped.</td>
+        <td>?string</td>
+        <td>Optional. The visible link text. If null, the URL is used as the link text.</td>
+        <td>null</td>
       </tr>
       <tr>
         <td>$attributes</td>
         <td>array</td>
-        <td>An optional array of key-value pairs for additional attributes. These values will be automatically escaped.</td>
+        <td>Optional. An associative array of HTML attributes to apply to the anchor tag, e.g., <code>['class' => 'btn']</code>.</td>
+        <td>[]</td>
       </tr>
     </tbody>
   </table>
@@ -47,44 +48,25 @@
     <tbody>
       <tr>
         <td>string</td>
-        <td>The complete HTML anchor tag as a string.</td>
+        <td>The generated HTML anchor tag.</td>
       </tr>
     </tbody>
   </table>
   <h2>Example Usage</h2>
 [code=php]
-// Basic usage with just URL
+// Basic link with auto-resolved URL
+echo anchor('products/view/42', 'View Product');
+// Output: <a href="https://example.com/products/view/42">View Product</a>
+
+// Link with HTML attributes
+echo anchor('login', 'Sign In', ['class' => 'btn btn-primary']);
+// Output: <a href="https://example.com/login" class="btn btn-primary">Sign In</a>
+
+// External link (no BASE_URL prepended)
+echo anchor('https://example.com', 'External Site');
+// Output: <a href="https://example.com">External Site</a>
+
+// Using URL as link text
 echo anchor('contact');
-// Output: &lt;a href="contact"&gt;contact&lt;/a&gt;
-
-// Basic usage with URL and text
-echo anchor('contact', 'Get In Touch');
-// Output: &lt;a href="contact"&gt;Get In Touch&lt;/a&gt;
-
-// With attributes
-echo anchor('logout', 'Sign Out', ['class' => 'btn btn-danger', 'rel' => 'nofollow']);
-// Output: &lt;a href="logout" class="btn btn-danger" rel="nofollow"&gt;Sign Out&lt;/a&gt;
-
-// External link with target and rel attributes
-echo anchor('https://github.com/trongate', 'View Repo', ['target' => '_blank', 'rel' => 'noopener noreferrer']);
-// Output: &lt;a href="https://github.com/trongate" target="_blank" rel="noopener noreferrer"&gt;View Repo&lt;/a&gt;
-
-// Using HTML within text parameter (intentionally not escaped)
-echo anchor('contact', '&lt;i class="fa fa-envelope"&gt;&lt;/i&gt; Contact Us');
-// Output: &lt;a href="contact"&gt;&lt;i class="fa fa-envelope"&gt;&lt;/i&gt; Contact Us&lt;/a&gt;[/code]
-  <h2>Security Considerations</h2>
-
-    <p><strong>Important:</strong> The <code>$text</code> parameter is not automatically escaped. If displaying user-generated content, use the <code>out()</code> function to prevent XSS attacks.</p>
-    
-    <p><strong>Unsafe Example (Vulnerable to XSS):</strong></p>
-[code=php]
-echo anchor('profile', $user_name); 
-// Output (potentially unsafe): &lt;a href="profile"&gt;&lt;script&gt;alert('XSS')&lt;/script&gt;&lt;/a&gt;[/code]
-    <p><strong>Safe Example (Escaped Output):</strong></p>
-
-[code=php]
-echo anchor('profile', out($user_name)); 
-// Output: &lt;a href="profile"&gt;John Doe&lt;/a&gt;[/code]
-    <p><strong>Note:</strong> The <code>$url</code> and <code>$attributes</code> parameters are automatically escaped for security.</p>
-
+// Output: <a href="https://example.com/contact">contact</a>[/code]
 </div>

--- a/assets/reference/helpers/url_helpers/current_url.html
+++ b/assets/reference/helpers/url_helpers/current_url.html
@@ -3,7 +3,7 @@
   <p class="signature">function current_url(): string</p>
   <h2>Description</h2>
   <div class="description">
-    <p>Get the current URL of the web page.</p>
+    <p>Returns the full URL of the currently requested web page.</p>
   </div>
   <h2>Return Value</h2>
   <table>
@@ -16,12 +16,12 @@
     <tbody>
       <tr>
         <td>string</td>
-        <td>The current URL as a string.</td>
+        <td>The full URL of the current page.</td>
       </tr>
     </tbody>
   </table>
   <h2>Example Usage</h2>
 [code=php]
-echo current_url();
-// Output: http://example.com/current_page[/code]
+$url = current_url();
+echo $url; // e.g., "https://example.com/products/view/42"[/code]
 </div>

--- a/assets/reference/helpers/url_helpers/get_last_segment.html
+++ b/assets/reference/helpers/url_helpers/get_last_segment.html
@@ -3,28 +3,8 @@
   <p class="signature">function get_last_segment(): string</p>
   <h2>Description</h2>
   <div class="description">
-    <p>
-      Retrieves the value of the last segment of the current URL. It extracts the last segment by utilizing the 'get_last_part' function, which splits the URL by '/' and returns the last element.
-   </p>
+    <p>Returns the value of the last segment in the current URL.</p>
   </div>
-  <h2>Parameters</h2>
-  <table>
-    <thead>
-      <tr>
-        <th>Parameter</th>
-        <th>Type</th>
-        <th>Description</th>
-        <th>Default</th>
-        <th>Required</th>
-      </tr>
-    </thead>
-    <tbody>
-      <!-- This method does not accept any parameters -->
-      <tr>
-        <td colspan="5">This method does not accept any parameters.</td>
-      </tr>
-    </tbody>
-  </table>
   <h2>Return Value</h2>
   <table>
     <thead>
@@ -36,12 +16,12 @@
     <tbody>
       <tr>
         <td>string</td>
-        <td>The last segment of the URL.</td>
+        <td>The last segment of the current URL.</td>
       </tr>
     </tbody>
   </table>
   <h2>Example Usage</h2>
-  <div>
-    [code=php]$invoice_ref = get_last_segment();[/code]
-  </div>
+[code=php]
+// URL: https://example.com/products/view/42
+$last = get_last_segment(); // returns "42"[/code]
 </div>

--- a/assets/reference/helpers/url_helpers/get_num_segments.html
+++ b/assets/reference/helpers/url_helpers/get_num_segments.html
@@ -3,28 +3,8 @@
   <p class="signature">function get_num_segments(): int</p>
   <h2>Description</h2>
   <div class="description">
-    <p>
-      Retrieves the number of segments in the current URL after the base URL. It calculates the number of segments by removing the base URL and then splitting the remaining path into segments using '/' as the delimiter.
-   </p>
+    <p>Returns the number of segments in the current URL after the base URL.</p>
   </div>
-  <h2>Parameters</h2>
-  <table>
-    <thead>
-      <tr>
-        <th>Parameter</th>
-        <th>Type</th>
-        <th>Description</th>
-        <th>Default</th>
-        <th>Required</th>
-      </tr>
-    </thead>
-    <tbody>
-      <!-- This method does not accept any parameters -->
-      <tr>
-        <td colspan="5">This method does not accept any parameters.</td>
-      </tr>
-    </tbody>
-  </table>
   <h2>Return Value</h2>
   <table>
     <thead>
@@ -41,7 +21,7 @@
     </tbody>
   </table>
   <h2>Example Usage</h2>
-  <div>
-    [code=php]$num_url_segments = get_num_segments();[/code]
-  </div>
+[code=php]
+// URL: https://example.com/products/category/electronics
+$num = get_num_segments(); // returns 3[/code]
 </div>

--- a/assets/reference/helpers/url_helpers/previous_url.html
+++ b/assets/reference/helpers/url_helpers/previous_url.html
@@ -3,7 +3,7 @@
   <p class="signature">function previous_url(): string</p>
   <h2>Description</h2>
   <div class="description">
-    <p>Retrieves the URL of the previous page, if available.</p>
+    <p>Returns the URL of the previously visited page, if available. This is typically used for "back" links or redirecting users after form submission.</p>
   </div>
   <h2>Return Value</h2>
   <table>
@@ -16,12 +16,12 @@
     <tbody>
       <tr>
         <td>string</td>
-        <td>Returns the URL of the previous page as a string.</td>
+        <td>The URL of the previous page, or an empty string if no previous URL is available.</td>
       </tr>
     </tbody>
   </table>
   <h2>Example Usage</h2>
 [code=php]
-echo previous_url();
-// Output: URL of the previous page if available, otherwise an empty string.[/code]
+$back = previous_url();
+echo $back; // e.g., "https://example.com/products"[/code]
 </div>

--- a/assets/reference/helpers/url_helpers/redirect.html
+++ b/assets/reference/helpers/url_helpers/redirect.html
@@ -3,32 +3,47 @@
   <p class="signature">function redirect(string $target_url): void</p>
   <h2>Description</h2>
   <div class="description">
-    <p>Perform an HTTP redirect to the specified URL.</p>
+    <p>Performs an HTTP redirect to the specified URL. If the target URL does not start with <code>http</code>, it is assumed to be an internal route and <code>BASE_URL</code> is automatically prepended.</p>
   </div>
   <h2>Parameters</h2>
-  <table class="params-table">
+  <table>
     <thead>
       <tr>
         <th>Parameter</th>
         <th>Type</th>
         <th>Description</th>
+        <th>Default</th>
       </tr>
     </thead>
     <tbody>
       <tr>
         <td>$target_url</td>
         <td>string</td>
-        <td>The URL to which the redirect should occur.</td>
+        <td>The URL or internal route to redirect to.</td>
+        <td>N/A</td>
       </tr>
     </tbody>
   </table>
   <h2>Return Value</h2>
-  <p>This function does not return a value.</p>
+  <table>
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>void</td>
+        <td>This function does not return a value; it terminates execution after sending the redirect header.</td>
+      </tr>
+    </tbody>
+  </table>
   <h2>Example Usage</h2>
 [code=php]
-redirect("/login");
-// Redirects the user to the login page.
+// Redirect to an external URL
+redirect('https://example.com');
 
-redirect("https://example.com");
-// Redirects the user to https://example.com.[/code]
+// Redirect to an internal route (BASE_URL is prepended)
+redirect('products/view/42');[/code]
 </div>

--- a/assets/reference/helpers/url_helpers/remove_query_string.html
+++ b/assets/reference/helpers/url_helpers/remove_query_string.html
@@ -3,7 +3,7 @@
   <p class="signature">function remove_query_string(string $string): string</p>
   <h2>Description</h2>
   <div class="description">
-    <p>Remove query string from a URL.</p>
+    <p>Removes the query string from a given URL and returns the clean URL.</p>
   </div>
   <h2>Parameters</h2>
   <table>
@@ -40,9 +40,8 @@
     </tbody>
   </table>
   <h2>Example Usage</h2>
-  <div>
-    [code=php]
-echo remove_query_string("https://example.com/page?param=value");
-// Output: https://example.com/page[/code]
-  </div>
+[code=php]
+$url = "https://example.com/page?name=test&id=5";
+$clean = remove_query_string($url);
+echo $clean; // "https://example.com/page"[/code]
 </div>

--- a/assets/reference/helpers/url_helpers/segment.html
+++ b/assets/reference/helpers/url_helpers/segment.html
@@ -1,16 +1,11 @@
 <div class="container">
   <h1>segment()</h1>
-
   <p class="signature">function segment(int $num, ?string $var_type = null): mixed</p>
-
   <h2>Description</h2>
   <div class="description">
-    <p>
-      Retrieves a specific segment from the current URL. Unlike earlier framework conventions that implicitly injected URL values into controller methods, <code>segment()</code> makes URL input <strong>explicit</strong>, <strong>predictable</strong>, and <strong>secure</strong>.
-   </p>
-
+    <p>Retrieves a specific segment from the current URL path using a 1-based index. URL segments are not implicitly injected into controller methods; they must be explicitly retrieved using this helper.</p>
+    <p>Optional type casting is performed using PHP's native <code>settype()</code> function, allowing input to be coerced at the point of retrieval. Supported types include: <code>int</code>, <code>integer</code>, <code>float</code>, <code>double</code>, <code>string</code>, <code>bool</code>, <code>boolean</code>, <code>array</code>, <code>object</code>, and <code>null</code>.</p>
   </div>
-
   <h2>Parameters</h2>
   <table>
     <thead>
@@ -25,21 +20,17 @@
       <tr>
         <td>$num</td>
         <td>int</td>
-        <td>The position of the URL segment to retrieve (starting from 1).</td>
+        <td>The 1-based index of the URL segment to retrieve.</td>
         <td>N/A</td>
       </tr>
       <tr>
         <td>$var_type</td>
-        <td>string|null</td>
-        <td>
-          Optional. If provided, the segment value is coerced to this PHP data type using <code>settype()</code>.
-          This enables type safety at the point of retrieval.
-        </td>
+        <td>?string</td>
+        <td>Optional. A PHP data type to cast the segment value to. If null, the segment is returned as a string.</td>
         <td>null</td>
       </tr>
     </tbody>
   </table>
-
   <h2>Return Value</h2>
   <table>
     <thead>
@@ -51,69 +42,18 @@
     <tbody>
       <tr>
         <td>mixed</td>
-        <td>
-          The value of the requested URL segment. Returns an empty string if the segment does not exist.
-        </td>
+        <td>The value of the requested URL segment, cast to the specified type if provided. Returns an empty string if the segment does not exist.</td>
       </tr>
     </tbody>
   </table>
+  <h2>Example Usage</h2>
+[code=php]
+// URL: https://example.com/users/profile/123
 
-  <h2>Basic Example</h2>
-[code=php]echo segment(1);
-// URL: https://example.com/blog/view/hello-world
-// Output: blog[/code]
+$module = segment(1);   // returns "users"
+$action = segment(2);   // returns "profile"
+$user_id = segment(3, 'int'); // returns 123 (as integer)
 
-  <h2>Type-Safe Numeric ID</h2>
-  <p>
-    Passing a second argument enables automatic type coercion. This is especially useful for numeric identifiers and makes SQL injection attempts ineffective.
- </p>
-
-[code=php]public function profile() {
-  $user_id = segment(3, 'int');
-
-  if ($user_id &lt;= 0) {
-    http_response_code(400);
-    die('Invalid user ID');
-  }
-
-  $user = $this-&gt;model-&gt;get_user($user_id);
-}[/code]
-
-  <h2>String Slug Example</h2>
-  <p>
-    Explicitly fetching string values improves readability and makes the source of external input immediately obvious.
- </p>
-
-[code=php]public function show() {
-  $slug = segment(3, 'string');
-
-  if ($slug === '') {
-    redirect('blog');
-  }
-
-  $post = $this-&gt;model-&gt;get_by_slug($slug);
-}[/code]
-
-  <h2>Boolean Flag Example</h2>
-  <p>
-    Boolean coercion is useful for toggle-style routes where values such as <code>1</code> and <code>0</code> are expected.
- </p>
-
-[code=php]public function toggle() {
-  $active = segment(3, 'bool');
-  $this-&gt;model-&gt;set_status($active);
-}[/code]
-
-  <h2>Supported Data Types</h2>
-  <ul>
-    <li><code>'int'</code> - integer values</li>
-    <li><code>'float'</code> - decimal values</li>
-    <li><code>'bool'</code> - boolean values</li>
-    <li><code>'string'</code> - string values</li>
-    <li><code>'array'</code> - advanced or edge cases</li>
-  </ul>
-
-  <p>
-    By combining explicit URL access with native PHP type coercion, <code>segment()</code> encourages safer, clearer, and more maintainable controller code.
- </p>
+// returns empty string when segment doesn't exist
+segment(5); // returns ""[/code]
 </div>


### PR DESCRIPTION
## Summary

Adds 8 reference pages for the URL Helpers in .

### Pages

| Function | Description | Examples |
|---|---|---|
|  | HTML anchor tag with base URL resolution & XSS protection | 4 examples |
|  | Retrieve current page URL | 1 example |
|  | Get last URL segment | 1 example |
|  | Count URL segments | 1 example |
|  | Get previous page URL | 1 example |
|  | HTTP redirect with auto base URL prepend | 2 examples |
|  | Strip query strings from URLs | 1 example |
|  | Extract URL segment with optional type casting | 4 examples