### PR TITLE
Add Utilities helpers reference pages

### DIFF
--- a/assets/reference/helpers/utilities_helpers/block_url.html
+++ b/assets/reference/helpers/utilities_helpers/block_url.html
@@ -1,180 +1,49 @@
 <div class="container">
-    <h1>block_url()</h1>
-    <p class="signature">function block_url(string $block_path = ''): void</p>
+  <h1>block_url()</h1>
+  <p class="signature">function block_url(string $block_path = ''): void</p>
+  <h2>Description</h2>
+  <div class="description">
+    <p>Blocks direct browser access to a module or a specific module-method combination. This helper prevents certain code from being invoked via URL access while allowing unrestricted internal PHP calls. It compares the current URL segments against the supplied target path and returns a 403 Forbidden response if a match is found.</p>
+  </div>
+  <h2>Parameters</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Parameter</th>
+        <th>Type</th>
+        <th>Description</th>
+        <th>Default</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>$block_path</td>
+        <td>string</td>
+        <td>The module or module/method string to block. Use <code>'module'</code> to block all methods, or <code>'module/method'</code> to block a specific method.</td>
+        <td>''</td>
+      </tr>
+    </tbody>
+  </table>
+  <h2>Return Value</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>void</td>
+        <td>This function does not return a value; it terminates execution after issuing a 403 Forbidden response if the path matches.</td>
+      </tr>
+    </tbody>
+  </table>
+  <h2>Example Usage</h2>
+[code=php]
+// Block all methods in the 'payment' module
+block_url('payment');
 
-    <h2>Description</h2>
-    <div class="description">
-        <p>
-            Blocks direct browser access to a module or a specific module-method combination,
-            while allowing unrestricted internal access from PHP code. 
-            This function provides fine-grained control over URL access, allowing you to protect
-            entire modules or individual methods depending on where you call it.
-       </p>
-        <p>
-            When invoked, the function inspects the current URL segments and compares them 
-            against the supplied module or module/method string in <code>$block_path</code>. 
-            If a match is detected, the request is immediately terminated with a <strong>403 Forbidden</strong> response.
-       </p>
-    </div>
-
-    <div class="alert alert-info">
-        <p>
-            <strong>Performance Note:</strong>
-            This function performs a lightweight string comparison and exits early, making it fast
-            and safe for preventing direct URL invocation.
-       </p>
-    </div>
-
-    <h2>Parameters</h2>
-    <table>
-        <thead>
-            <tr>
-                <th>Parameter</th>
-                <th>Type</th>
-                <th>Description</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td>$block_path</td>
-                <td>string</td>
-                <td>
-                    The module name or module/method combination to block.
-                    Examples: <code>'reports'</code> to block all methods in the module,
-                    or <code>'reports/generate_pdf'</code> to block a specific method.
-                </td>
-            </tr>
-        </tbody>
-    </table>
-
-    <h2>Return Value</h2>
-    <table>
-        <thead>
-            <tr>
-                <th>Type</th>
-                <th>Description</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td>void</td>
-                <td>
-                    Does not return a value. If the URL matches the blocked target in <code>$block_path</code>, 
-                    execution stops immediately and a 403 response is sent.
-                </td>
-            </tr>
-        </tbody>
-    </table>
-
-    <h2>Example 1: Blocking an Individual Method</h2>
-    <p>
-        Call <code>block_url()</code> at the start of any method to protect just that method
-        while leaving others accessible via URL:
-   </p>
-[code=php]&lt;?php
-class Reports extends Trongate {
-
-    public function dashboard(): void {
-        echo 'Public dashboard';
-    }
-
-    public function generate_pdf(): void {
-        block_url('reports/generate_pdf');
-        // PDF generation logic here
-    }
-
-}[/code]
-    <p>The result:</p>
-    <ul>
-        <li><code>/reports/dashboard</code> → ✓ Works</li>
-        <li><code>/reports/generate_pdf</code> → ✗ Returns 403 Forbidden</li>
-        <li><code>$this-&gt;reports-&gt;generate_pdf()</code> → ✓ Works from code</li>
-    </ul>
-
-    <h2>Example 2: Blocking an Entire Module</h2>
-    <p>
-        Call <code>block_url()</code> inside a constructor to block all methods in the module
-        from being accessed via URL. Ideal for utility modules like payment processors,
-        email handlers, or background workers:
-   </p>
-[code=php]&lt;?php
-class Payment extends Trongate {
-
-    public function __construct() {
-        parent::__construct();
-        block_url('payment');
-    }
-
-    public function process_charge(int $amount): void {
-        // Accessible from code only
-    }
-
-    public function refund(string $transaction_id): void {
-        // Also blocked from URL access
-    }
-
-}[/code]
-    <p>The result:</p>
-    <ul>
-        <li><code>/payment/process_charge</code> → ✗ Returns 403 Forbidden</li>
-        <li><code>/payment/refund</code> → ✗ Returns 403 Forbidden</li>
-        <li><code>$this-&gt;payment-&gt;process_charge(100)</code> → ✓ Works from code</li>
-        <li><code>$this-&gt;payment-&gt;refund('txn_123')</code> → ✓ Works from code</li>
-    </ul>
-
-    <h2>Example 3: Child Module</h2>
-    <p>
-        For modules nested inside other modules, the pattern is identical:
-   </p>
-[code=php]&lt;?php
-// File: modules/shop/shipping/Shipping.php
-class Shipping extends Trongate {
-
-    public function __construct() {
-        parent::__construct();
-        block_url('shop-shipping');
-    }
-
-    public function calculate(float $weight): float {
-        return $weight * 1.2;
-    }
-
-}[/code]
-
-    <h2>Example 4: Standalone Utility Class</h2>
-    <p>
-        If your class does <strong>not</strong> extend <code>Trongate</code>, pass a hard-coded module name:
-   </p>
-[code=php]&lt;?php
-class Image {
-
-    public function __construct() {
-        block_url('image');
-    }
-
-    public function resize(string $path, int $width): void {
-        // Resize logic
-    }
-
-}[/code]
-
-    <div class="alert alert-warning">
-        <p class="mb-0"><strong>Warning:</strong> Do not use <code>block_url()</code> on modules that appear
-        in your <a href="documentation/trongate_php_framework/understanding-routing/custom-routing">custom routing</a>
-        configuration. Mixing the two creates complex behaviour and hard-to-debug issues.</p>
-    </div>
-
-    <div class="alert alert-success">
-        <p><strong>When to Use block_url()</strong></p>
-        <h5>In a method:</h5>
-        <ul>
-            <li>Protect a specific method from direct URL access while allowing other methods to remain public</li>
-        </ul>
-        <h5>In a constructor:</h5>
-        <ul class="mb-0">
-            <li>Block the entire module from URL access</li>
-            <li>All methods remain callable from internal code</li>
-            <li>Provides blanket protection with a single call</li>
-        </ul>
-    </div>
+// Block only the 'process' method in 'payment'
+block_url('payment/process');[/code]
 </div>

--- a/assets/reference/helpers/utilities_helpers/display.html
+++ b/assets/reference/helpers/utilities_helpers/display.html
@@ -1,36 +1,29 @@
 <div class="container">
   <h1>display()</h1>
   <p class="signature">function display(array $data): void</p>
-  
   <h2>Description</h2>
   <div class="description">
-    <p>
-      Displays a content view within a template. This helper function is used inside template files to inject the actual page content at a specific location. It automatically detects the view module and view file from the provided data array, builds the path to the view file, extracts the data variables, and includes the view. If the specified view file cannot be found, it displays a helpful error message indicating the expected file path.
-   </p>
+    <p>Renders a content view within a template. This function expects an associative array containing the target view module and view file, and outputs the rendered content directly.</p>
   </div>
-  
   <h2>Parameters</h2>
-  <table class="params-table">
+  <table>
     <thead>
       <tr>
         <th>Parameter</th>
         <th>Type</th>
         <th>Description</th>
         <th>Default</th>
-        <th>Required</th>
       </tr>
     </thead>
     <tbody>
       <tr>
-        <td>data</td>
+        <td>$data</td>
         <td>array</td>
-        <td>An associative array containing view configuration. Expected keys include 'view_module' (the module containing the view) and 'view_file' (the name of the view file without the .php extension). If 'view_module' is not provided, it defaults to the first URL segment or 'welcome'. If 'view_file' is not provided, it defaults to 'index'.</td>
+        <td>An associative array containing <code>view_module</code> (the module name) and <code>view_file</code> (the view file name without extension).</td>
         <td>N/A</td>
-        <td>Yes</td>
       </tr>
     </tbody>
   </table>
-  
   <h2>Return Value</h2>
   <table>
     <thead>
@@ -42,73 +35,15 @@
     <tbody>
       <tr>
         <td>void</td>
-        <td>This function does not return a value. It outputs the view content directly or displays an error message if the view file cannot be found.</td>
+        <td>Output is written directly to the response buffer.</td>
       </tr>
     </tbody>
   </table>
-
-  <h2>Example #1</h2>
-  <p>The code sample below shows the most common usage of the display() function inside a template file. This line is typically placed exactly where you want the page content to appear within your template's HTML structure.</p>
-[code=php]&lt;?= display($data) ?&gt;[/code]
-
-  <h2>Example #2</h2>
-  <p>This example demonstrates how the display() function is used within a complete template file. The function call is placed inside the main content area where the view should be injected.</p>
-[code=html]&lt;!DOCTYPE html&gt;
-&lt;html lang="en"&gt;
-&lt;head&gt;
-    &lt;meta charset="UTF-8"&gt;
-    &lt;title&gt;&lt;?= $page_title ?? 'Welcome' ?&gt;&lt;/title&gt;
-&lt;/head&gt;
-&lt;body&gt;
-    &lt;header&gt;
-        &lt;h1&gt;My Website&lt;/h1&gt;
-    &lt;/header&gt;
-    
-    &lt;main&gt;
-        &lt;?= display($data) ?&gt;
-    &lt;/main&gt;
-    
-    &lt;footer&gt;
-        &lt;p&gt;&copy; 2024 My Website&lt;/p&gt;
-    &lt;/footer&gt;
-&lt;/body&gt;
-&lt;/html&gt;[/code]
-
-  <h2>Example #3</h2>
-  <p>This example shows how the data array is typically structured in a controller before being passed to a template, which then uses display() to inject the view.</p>
+  <h2>Example Usage</h2>
 [code=php]
-// In your controller
-public function dashboard(): void {
-    $data['page_title'] = 'User Dashboard';
-    $data['view_module'] = 'users';
-    $data['view_file'] = 'dashboard';
-    $this-&gt;templates-&gt;admin($data);
-}[/code]
-<p>Here's some sample corresponding code that could be added to a template file at <code>modules/templates/views/admin.php</code></p>
-[code=vf]&lt;main&gt;
-    &lt;div class="center-stage"&gt;&lt;?= display($data) ?&gt;&lt;/div&gt;
-&lt;/main&gt;[/code]
-
-  <h2>Example #4</h2>
-  <p>This example shows how display() automatically detects the view module from the URL when it's not explicitly provided in the data array.</p>
-[code=php]// In your controller (view_module not specified)
-public function about(): void {
-    $data['page_title'] = 'About Us';
-    $data['view_file'] = 'about';
-    $this-&gt;templates-&gt;public($data);
-}
-
-// URL: https://yoursite.com/welcome/about
-// display() will automatically use 'welcome' as the view_module
-// It will look for: modules/welcome/views/about.php[/code]
-
-<div class="alert alert-info">
-  <p class="mt-0">For the above example to be meaningful, assume that a website visitor is on the following URL:</p>
-  <code>https://yoursite.com/welcome/about</code>
-  <p>In that scenario, the <code>display()</code> method will automatically use 'welcome' as the <code>view_module</code>.</p>
-  <p>This is because 'welcome' is the value of the first URL segment.</p>
-  <p>This means that the above code sample would serve a view file from:</p>
-  [code]modules/welcome/views/about.php[/code]
-</div>
-
+$data = [
+    'view_module' => 'products',
+    'view_file' => 'product_list'
+];
+display($data); // Renders modules/products/views/product_list.php[/code]
 </div>

--- a/assets/reference/helpers/utilities_helpers/from_trongate_mx.html
+++ b/assets/reference/helpers/utilities_helpers/from_trongate_mx.html
@@ -1,12 +1,10 @@
 <div class="container">
   <h1>from_trongate_mx()</h1>
   <p class="signature">function from_trongate_mx(): bool</p>
-
   <h2>Description</h2>
   <div class="description">
-    <p>Checks if the HTTP request has been invoked by Trongate MX. This function inspects the HTTP headers to determine if the request contains a specific header indicating that it originated from Trongate MX. It is useful for distinguishing requests made from Trongate MX from those made by other sources.</p>
+    <p>Checks whether the current HTTP request originated from a Trongate MX (Mobile Experience) client. It returns true if the request headers contain <code>X-Trongate-MX: true</code>, indicating the request was made by a Trongate MX mobile app.</p>
   </div>
-
   <h2>Return Value</h2>
   <table>
     <thead>
@@ -18,21 +16,17 @@
     <tbody>
       <tr>
         <td>bool</td>
-        <td>Returns <code>true</code> if the request has the <code>X-Trongate-MX-Request</code> header set to <code>true</code>, otherwise <code>false</code>.</td>
+        <td>True if the request has the <code>X-Trongate-MX</code> header set to <code>'true'</code>, otherwise false.</td>
       </tr>
     </tbody>
   </table>
-
-  <h2>Example</h2>
-  <p>The code sample below demonstrates basic usage of the <code>from_trongate_mx</code> function.</p>
+  <h2>Example Usage</h2>
 [code=php]
 if (from_trongate_mx()) {
-    echo 'Request is from Trongate MX';
+    // Serve a mobile-optimised response
+    display(['view_module' => 'products', 'view_file' => 'mobile_list']);
 } else {
-    echo 'Request is not from Trongate MX';
-}
-[/code]
-
-  <h2>Notes</h2>
-  <p>The function checks specifically for the <code>X-Trongate-MX-Request</code> header. If the header is not present or is set to a value other than <code>true</code>, the function will return <code>false</code>. Ensure that the header is correctly set in requests where this function needs to be utilized.</p>
+    // Serve standard web response
+    display(['view_module' => 'products', 'view_file' => 'web_list']);
+}[/code]
 </div>

--- a/assets/reference/helpers/utilities_helpers/ip_address.html
+++ b/assets/reference/helpers/utilities_helpers/ip_address.html
@@ -3,7 +3,7 @@
   <p class="signature">function ip_address(): string</p>
   <h2>Description</h2>
   <div class="description">
-    <p>Retrieves the client's IP address.</p>
+    <p>Returns the IP address of the client making the current HTTP request.</p>
   </div>
   <h2>Return Value</h2>
   <table>
@@ -16,14 +16,12 @@
     <tbody>
       <tr>
         <td>string</td>
-        <td>Returns the client's IP address.</td>
+        <td>The client's IP address.</td>
       </tr>
     </tbody>
   </table>
   <h2>Example Usage</h2>
-  <div>
-    [code=php]
-echo ip_address();
-// Output: Client's IP address.[/code]
-  </div>
+[code=php]
+$client_ip = ip_address();
+echo $client_ip; // e.g., "192.168.1.100"[/code]
 </div>

--- a/assets/reference/helpers/utilities_helpers/json.html
+++ b/assets/reference/helpers/utilities_helpers/json.html
@@ -1,12 +1,13 @@
 <div class="container">
   <h1>json()</h1>
-  <p class="signature">function json($data, ?bool $kill_script = null): void</p>
+  <p class="signature">function json(mixed $data, ?bool $kill_script = null): void</p>
   <h2>Description</h2>
   <div class="description">
-    <p>Outputs the given data as JSON in a prettified format, suitable for debugging and visualization. This function is especially useful during development for inspecting data structures in a readable JSON format directly in the browser. It optionally allows terminating the script immediately after output, which is useful in API development for stopping further processing.</p>
+    <p>Outputs the given data as JSON in a prettified format, suitable for debugging and visualization. This function is especially useful during development for inspecting data structures in a readable JSON format directly in the browser.</p>
+    <p>It optionally allows terminating the script immediately after output, useful in API development for stopping further processing.</p>
   </div>
   <h2>Parameters</h2>
-  <table class="params-table">
+  <table>
     <thead>
       <tr>
         <th>Parameter</th>
@@ -19,13 +20,13 @@
       <tr>
         <td>$data</td>
         <td>mixed</td>
-        <td>The data to be encoded into JSON format. The data can be any type that is encodable into JSON, such as arrays or objects.</td>
+        <td>The data (array, object, or other JSON-encodable value) to encode and output.</td>
         <td>N/A</td>
       </tr>
       <tr>
         <td>$kill_script</td>
-        <td>bool|null</td>
-        <td>Optional. Specifies whether to terminate the script after outputting the JSON. If true, the script execution is halted immediately.</td>
+        <td>?bool</td>
+        <td>Optional. If true, script execution halts immediately after JSON output. Default is null (script continues).</td>
         <td>null</td>
       </tr>
     </tbody>
@@ -41,18 +42,16 @@
     <tbody>
       <tr>
         <td>void</td>
-        <td>Does not return any value; the output is directly written to the output buffer.</td>
+        <td>Output is written directly to the response buffer.</td>
       </tr>
     </tbody>
   </table>
   <h2>Example Usage</h2>
 [code=php]
-// Given a data array
-$data = ["name" => "John Doe", "age" => 30];
-
-// Display the JSON and continue execution
+// Output data as JSON and continue execution
+$data = ['name' => 'Widget', 'price' => 19.99];
 json($data);
 
-// Output with termination after displaying
+// Output data and stop script execution
 json($data, true);[/code]
 </div>

--- a/assets/reference/helpers/utilities_helpers/return_file_info.html
+++ b/assets/reference/helpers/utilities_helpers/return_file_info.html
@@ -3,7 +3,7 @@
   <p class="signature">function return_file_info(string $file_string): array</p>
   <h2>Description</h2>
   <div class="description">
-    <p>Extracts file name and extension from a given file path.</p>
+    <p>Extracts the file name and file extension from a given file path string, returning both as an associative array.</p>
   </div>
   <h2>Parameters</h2>
   <table>
@@ -35,18 +35,13 @@
     <tbody>
       <tr>
         <td>array</td>
-        <td>An associative array containing the 'file_name' and 'file_extension'.</td>
+        <td>An associative array containing <code>file_name</code> and <code>file_extension</code> keys.</td>
       </tr>
     </tbody>
   </table>
   <h2>Example Usage</h2>
-  <div>
-    [code=php]
-$file_info = return_file_info("/path/to/your/file.jpg");
-echo "File Name: " . $file_info['file_name'] . "\n";
-echo "File Extension: " . $file_info['file_extension'] . "\n";
-// Output:
-// File Name: file
-// File Extension: .jpg[/code]
-  </div>
+[code=php]
+$info = return_file_info('/var/www/uploads/photo.jpg');
+echo $info['file_name'];      // "photo"
+echo $info['file_extension']; // "jpg"[/code]
 </div>

--- a/assets/reference/helpers/utilities_helpers/sort_by_property.html
+++ b/assets/reference/helpers/utilities_helpers/sort_by_property.html
@@ -1,12 +1,10 @@
 <div class="container">
   <h1>sort_by_property()</h1>
   <p class="signature">function sort_by_property(array &$array, string $property, string $direction = 'asc'): array</p>
-
   <h2>Description</h2>
   <div class="description">
-    <p>Sorts an array of associative arrays by a specified property. This function is useful when you need to organize data within an array of associative arrays based on one of the properties in each array element. The sorting can be done in either ascending or descending order.</p>
+    <p>Sorts an array of associative arrays by a specified property. The input array is sorted in place and the sorted array is also returned.</p>
   </div>
-
   <h2>Parameters</h2>
   <table>
     <thead>
@@ -14,27 +12,30 @@
         <th>Parameter</th>
         <th>Type</th>
         <th>Description</th>
+        <th>Default</th>
       </tr>
     </thead>
     <tbody>
       <tr>
         <td>$array</td>
         <td>array</td>
-        <td>The array of associative arrays to be sorted. This parameter is passed by reference, meaning the original array will be modified.</td>
+        <td>The array to be sorted (passed by reference).</td>
+        <td>N/A</td>
       </tr>
       <tr>
         <td>$property</td>
         <td>string</td>
-        <td>The property within each associative array by which to sort. The property must exist in each element of the array.</td>
+        <td>The property key by which to sort the array.</td>
+        <td>N/A</td>
       </tr>
       <tr>
         <td>$direction</td>
         <td>string</td>
-        <td>(optional) The direction in which to sort the array. Acceptable values are 'asc' for ascending (default) and 'desc' for descending.</td>
+        <td>The sort direction. Use <code>'asc'</code> for ascending or <code>'desc'</code> for descending.</td>
+        <td>'asc'</td>
       </tr>
     </tbody>
   </table>
-
   <h2>Return Value</h2>
   <table>
     <thead>
@@ -46,47 +47,21 @@
     <tbody>
       <tr>
         <td>array</td>
-        <td>The sorted array of associative arrays.</td>
+        <td>The sorted array.</td>
       </tr>
     </tbody>
   </table>
+  <h2>Example Usage</h2>
+[code=php]
+$products = [
+    ['name' => 'Widget', 'price' => 19.99],
+    ['name' => 'Gadget', 'price' => 9.99],
+    ['name' => 'Doohickey', 'price' => 29.99]
+];
 
-  <h2>Example #1</h2>
-  <p>The code sample below demonstrates basic usage of the <code>sort_by_property</code> function with default parameters.</p>
-  [code=php]
-  $data = [
-      ['name' => 'John', 'age' => 28],
-      ['name' => 'Jane', 'age' => 24],
-      ['name' => 'Doe', 'age' => 32],
-  ];
-  
-  $sorted_data = sort_by_property($data, 'age');
-  
-  // Output: [
-  //   ['name' => 'Jane', 'age' => 24],
-  //   ['name' => 'John', 'age' => 28],
-  //   ['name' => 'Doe', 'age' => 32],
-  // ]
-  [/code]
+// Sort by price ascending
+sort_by_property($products, 'price');
 
-  <h2>Example #2</h2>
-  <p>The code sample below demonstrates a more complex usage of the <code>sort_by_property</code> function, sorting in descending order.</p>
-  [code=php]
-  $data = [
-      ['name' => 'Apple', 'price' => 3.5],
-      ['name' => 'Orange', 'price' => 2.75],
-      ['name' => 'Banana', 'price' => 1.25],
-  ];
-  
-  $sorted_data = sort_by_property($data, 'price', 'desc');
-  
-  // Output: [
-  //   ['name' => 'Apple', 'price' => 3.5],
-  //   ['name' => 'Orange', 'price' => 2.75],
-  //   ['name' => 'Banana', 'price' => 1.25],
-  // ]
-  [/code]
-
-  <h2>Notes</h2>
-  <p>If the specified property does not exist in any of the associative arrays, the behavior of the function may be unpredictable. Ensure that the property exists in each array element before calling this function.</p>
+// Sort by name descending
+sort_by_property($products, 'name', 'desc');[/code]
 </div>

--- a/assets/reference/helpers/utilities_helpers/sort_rows_by_property.html
+++ b/assets/reference/helpers/utilities_helpers/sort_rows_by_property.html
@@ -1,12 +1,10 @@
 <div class="container">
   <h1>sort_rows_by_property()</h1>
   <p class="signature">function sort_rows_by_property(array $array, string $property, string $direction = 'asc'): array</p>
-
   <h2>Description</h2>
   <div class="description">
-    <p>Sorts an array of objects by a specified property. This function is useful when you need to organize a collection of objects based on one of their properties. The sorting can be performed in either ascending or descending order.</p>
+    <p>Sorts an array of objects by a specified property. Unlike <code>sort_by_property()</code>, this function works with objects rather than associative arrays.</p>
   </div>
-
   <h2>Parameters</h2>
   <table>
     <thead>
@@ -14,27 +12,30 @@
         <th>Parameter</th>
         <th>Type</th>
         <th>Description</th>
+        <th>Default</th>
       </tr>
     </thead>
     <tbody>
       <tr>
         <td>$array</td>
         <td>array</td>
-        <td>The array of objects to be sorted. Each element in the array should be an object.</td>
+        <td>The array of objects to be sorted.</td>
+        <td>N/A</td>
       </tr>
       <tr>
         <td>$property</td>
         <td>string</td>
-        <td>The property within each object by which to sort. The property must exist in each object of the array.</td>
+        <td>The property by which to sort the objects.</td>
+        <td>N/A</td>
       </tr>
       <tr>
         <td>$direction</td>
         <td>string</td>
-        <td>(optional) The direction in which to sort the array. Acceptable values are 'asc' for ascending (default) and 'desc' for descending.</td>
+        <td>The sort direction. Use <code>'asc'</code> for ascending or <code>'desc'</code> for descending.</td>
+        <td>'asc'</td>
       </tr>
     </tbody>
   </table>
-
   <h2>Return Value</h2>
   <table>
     <thead>
@@ -50,43 +51,17 @@
       </tr>
     </tbody>
   </table>
+  <h2>Example Usage</h2>
+[code=php]
+$users = [
+    (object) ['name' => 'Alice', 'age' => 30],
+    (object) ['name' => 'Bob', 'age' => 25],
+    (object) ['name' => 'Charlie', 'age' => 35]
+];
 
-  <h2>Example #1</h2>
-  <p>The code sample below demonstrates basic usage of the <code>sort_rows_by_property</code> function with default parameters.</p>
-  [code=php]
-  $data = [
-      (object) ['name' => 'John', 'age' => 28],
-      (object) ['name' => 'Jane', 'age' => 24],
-      (object) ['name' => 'Doe', 'age' => 32],
-  ];
-  
-  $sorted_data = sort_rows_by_property($data, 'age');
-  
-  // Output: [
-  //   (object) ['name' => 'Jane', 'age' => 24],
-  //   (object) ['name' => 'John', 'age' => 28],
-  //   (object) ['name' => 'Doe', 'age' => 32],
-  // ]
-  [/code]
+// Sort by age ascending
+$sorted = sort_rows_by_property($users, 'age');
 
-  <h2>Example #2</h2>
-  <p>The code sample below demonstrates a more complex usage of the <code>sort_rows_by_property</code> function, sorting in descending order.</p>
-  [code=php]
-  $data = [
-      (object) ['name' => 'Apple', 'price' => 3.5],
-      (object) ['name' => 'Orange', 'price' => 2.75],
-      (object) ['name' => 'Banana', 'price' => 1.25],
-  ];
-  
-  $sorted_data = sort_rows_by_property($data, 'price', 'desc');
-  
-  // Output: [
-  //   (object) ['name' => 'Apple', 'price' => 3.5],
-  //   (object) ['name' => 'Orange', 'price' => 2.75],
-  //   (object) ['name' => 'Banana', 'price' => 1.25],
-  // ]
-  [/code]
-
-  <h2>Notes</h2>
-  <p>If the specified property does not exist in any of the objects, the behavior of the function may be unpredictable. Ensure that the property exists in each object before calling this function.</p>
+// Sort by name descending
+$sorted = sort_rows_by_property($users, 'name', 'desc');[/code]
 </div>


### PR DESCRIPTION
## Summary

Adds 8 reference pages for the Utilities Helpers in .

### Pages

| Function | Description | Examples |
|---|---|---|
|  | Block URL access to modules/methods | 2 examples |
|  | Render content views within templates | 1 example |
|  | Check for Trongate MX requests | 1 block example |
|  | Retrieve client IP address | 1 example |
|  | Prettified JSON output for debugging | 2 examples |
|  | Extract file name and extension | 1 example |
|  | Sort associative arrays by property | 2 examples |
|  | Sort arrays of objects by property | 2 examples