### PR TITLE
Quick Start chapter tweaks

### DIFF
--- a/assets/php_framework/0025Quick_Start/0030installation_and_configuration.html
+++ b/assets/php_framework/0025Quick_Start/0030installation_and_configuration.html
@@ -47,7 +47,7 @@ $databases = [
     ]
 ];[/code]
 
-<p>You can define multiple database groups by adding more entries to the <code>$databases</code> array. Each group can then be accessed from your models using the group name as a property (e.g., <code>$this-&gt;analytics</code>).</p>
+<p>You can define multiple database groups by adding more entries to the <code>$databases</code> array. Additional guidance is available on our documentation on <a href="documentation/trongate_php_framework/database-operations/working-with-multiple-databases">Working With Multiple Databases</a>.</p>
 
 <h2>4. Verify the Installation</h2>
 <p>Navigate to the URL you set in <code>BASE_URL</code>. You should see the default Trongate welcome page. If you see a blank page or an error, check that PHP 8.0+ is installed and that your <code>BASE_URL</code> is correct.</p>

--- a/assets/php_framework/0025Quick_Start/0040your_first_module.html
+++ b/assets/php_framework/0025Quick_Start/0040your_first_module.html
@@ -45,11 +45,3 @@ http://localhost/trongate/hello
 
 <p>That&rsquo;s all there is to it. Module controllers extend the <code>Trongate</code> class, views are plain PHP files, and URLs map directly to your module and method names. No configuration, no routing setup, no scaffolding commands.</p>
 
-<h2>Next Steps</h2>
-<p>Now that you have a working module, explore the rest of the documentation to learn about:</p>
-<ul>
-    <li><a href="documentation/trongate_php_framework/introduction/the-reason-why-trongate-v2-was-built">The philosophy behind Trongate v2</a></li>
-    <li><a href="documentation/trongate_php_framework/module-fundamentals/modules-ahoy">Modular MVC architecture</a></li>
-    <li><a href="documentation/trongate_php_framework/database-operations/getting-connected">Database interaction</a></li>
-    <li><a href="documentation/trongate_php_framework/form-handling/form-handling-fundamentals">Form handling</a></li>
-</ul>


### PR DESCRIPTION
Two fixes:

1. Removed 'Next Steps' section from 'Your First Module' page
2. Updated multiple databases line in 'Installation & Configuration' to link to the dedicated docs page on Working With Multiple Databases