### PR TITLE
Documentation corrections: module lists, feature-ref, constructor syntax

### DIFF
--- a/assets/php_framework/0030Basic_Concepts/0011everything_is_a_module.html
+++ b/assets/php_framework/0030Basic_Concepts/0011everything_is_a_module.html
@@ -48,9 +48,9 @@ modules/
         <tr><td><code>trongate_tokens</code></td><td>API token generation, validation, lifecycle</td></tr>
         <tr><td><code>trongate_administrators</code></td><td>Admin authentication and access control</td></tr>
         <tr><td><code>trongate_security</code></td><td>Permission checking, method-level access control</td></tr>
-        <tr><td><code>endpoint_listener</code></td><td>REST-style request handling</td></tr>
+        <tr><td><code>trongate_control</code></td><td>Module management and SQL import</td></tr>
         <tr><td><code>pagination</code></td><td>Page navigation for result sets</td></tr>
-        <tr><td><code>tasks</code></td><td>Background task management</td></tr>
+        <tr><td><code>welcome</code></td><td>Default landing page</td></tr>
     </tbody>
 </table>
 

--- a/assets/php_framework/0030Basic_Concepts/0020trongates_directory_structure.html
+++ b/assets/php_framework/0030Basic_Concepts/0020trongates_directory_structure.html
@@ -24,6 +24,36 @@ modules/
       welcome.php
       login.php
 [/code]
+<p>Trongate ships with the following built-in modules:</p>
+
+<table class="table sm">
+    <thead>
+        <tr>
+            <th>Module</th>
+            <th>What It Does</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr><td><code>db</code></td><td>Database connections and CRUD operations</td></tr>
+        <tr><td><code>file</code></td><td>File upload, move, copy, delete</td></tr>
+        <tr><td><code>flashdata</code></td><td>One-time session messages</td></tr>
+        <tr><td><code>form</code></td><td>Form input generation</td></tr>
+        <tr><td><code>image</code></td><td>Image resize, crop, rotate</td></tr>
+        <tr><td><code>language</code></td><td>Multilingual support</td></tr>
+        <tr><td><code>pagination</code></td><td>Page navigation</td></tr>
+        <tr><td><code>string_service</code></td><td>String manipulation</td></tr>
+        <tr><td><code>templates</code></td><td>Admin and public page rendering</td></tr>
+        <tr><td><code>trongate_administrators</code></td><td>Admin authentication</td></tr>
+        <tr><td><code>trongate_control</code></td><td>Module management and SQL import</td></tr>
+        <tr><td><code>trongate_security</code></td><td>Permission checking</td></tr>
+        <tr><td><code>trongate_tokens</code></td><td>API token generation and validation</td></tr>
+        <tr><td><code>url</code></td><td>URL generation and redirects</td></tr>
+        <tr><td><code>utilities</code></td><td>Debugging and utility tasks</td></tr>
+        <tr><td><code>validation</code></td><td>Form validation and error display</td></tr>
+        <tr><td><code>welcome</code></td><td>Default landing page</td></tr>
+    </tbody>
+</table>
+
 <div class="alert alert-info">
     <p><strong>Trongate v2 killed the controllers/ subfolder.</strong> You're welcome.</p>
 </div>

--- a/assets/php_framework/0030Basic_Concepts/0070loading_modules.html
+++ b/assets/php_framework/0030Basic_Concepts/0070loading_modules.html
@@ -36,7 +36,7 @@ class Members extends Trongate {
 $vat = $this-&gt;tax-&gt;calculate($amount);
 [/code]
 
-<p>Inside any view:</p>
+<p>Inside any view, use <span class="feature-ref">Modules::run()</span>:</p>
 [code=php]
 &lt;div&gt;&lt;?= Modules::run('users/stats', $user_data) ?&gt;&lt;/div&gt;
 [/code]

--- a/assets/php_framework/0045Intercepting_Requests/0030preventing_url_invocation.html
+++ b/assets/php_framework/0045Intercepting_Requests/0030preventing_url_invocation.html
@@ -87,8 +87,8 @@ class Reports extends Trongate {
 [code=php]&lt;?php
 class Payment extends Trongate {
 
-  public function __construct() {
-    parent::__construct();
+  public function __construct(?string $module_name = null) {
+    parent::__construct($module_name);
     block_url('payment');
   }
 


### PR DESCRIPTION
Four fixes:\n\n1. **Everything Is A Module** — replaced endpoint_listener and tasks (no longer in framework) with trongate_control and welcome\n2. **Directory Structure** — added table of 17 built-in modules under the modules/ section\n3. **Loading Modules** — added `<span class="feature-ref">Modules::run()</span>` as requested\n4. **Preventing URL Invocation** — constructor now uses correct signature: `?string $module_name = null` and `parent::__construct($module_name)`, matching actual framework code (e.g., Trongate_tokens, Trongate_administrators) and the guidance in Mastering Constructors\n\nModules::run() verification: the $data parameter is typed as `mixed`, which accepts strings, integers, arrays, objects, booleans, null — confirmed in engine/Modules.php. The page is technically correct.