### PR TITLE
Directory structure page: show real module list instead of 'users' example

### DIFF
--- a/assets/php_framework/0030Basic_Concepts/0011everything_is_a_module.html
+++ b/assets/php_framework/0030Basic_Concepts/0011everything_is_a_module.html
@@ -35,21 +35,21 @@ modules/
     </thead>
     <tbody>
         <tr><td><code>db</code></td><td>Database connections, queries, CRUD operations</td></tr>
-        <tr><td><code>form</code></td><td>All form helper functions</td></tr>
-        <tr><td><code>validation</code></td><td>Form validation, error display, CSRF protection</td></tr>
-        <tr><td><code>templates</code></td><td>Admin and public page rendering with layout support</td></tr>
         <tr><td><code>file</code></td><td>File upload, move, copy, delete, directory management</td></tr>
+        <tr><td><code>flashdata</code></td><td>One-time session messages</td></tr>
+        <tr><td><code>form</code></td><td>All form helper functions</td></tr>
         <tr><td><code>image</code></td><td>Image resize, crop, rotate, upload configuration</td></tr>
         <tr><td><code>language</code></td><td>Multilingual support, language file loading</td></tr>
+        <tr><td><code>pagination</code></td><td>Page navigation for result sets</td></tr>
         <tr><td><code>string_service</code></td><td>String manipulation helpers (truncate, split, filter)</td></tr>
+        <tr><td><code>templates</code></td><td>Admin and public page rendering with layout support</td></tr>
+        <tr><td><code>trongate_administrators</code></td><td>Admin authentication and access control</td></tr>
+        <tr><td><code>trongate_control</code></td><td>Module management and SQL import</td></tr>
+        <tr><td><code>trongate_security</code></td><td>Permission checking, method-level access control</td></tr>
+        <tr><td><code>trongate_tokens</code></td><td>API token generation, validation, lifecycle</td></tr>
         <tr><td><code>url</code></td><td>URL generation, redirects, anchor tags</td></tr>
         <tr><td><code>utilities</code></td><td>Block URL access, CORS handling, segment helper</td></tr>
-        <tr><td><code>flashdata</code></td><td>One-time session messages</td></tr>
-        <tr><td><code>trongate_tokens</code></td><td>API token generation, validation, lifecycle</td></tr>
-        <tr><td><code>trongate_administrators</code></td><td>Admin authentication and access control</td></tr>
-        <tr><td><code>trongate_security</code></td><td>Permission checking, method-level access control</td></tr>
-        <tr><td><code>trongate_control</code></td><td>Module management and SQL import</td></tr>
-        <tr><td><code>pagination</code></td><td>Page navigation for result sets</td></tr>
+        <tr><td><code>validation</code></td><td>Form validation, error display, CSRF protection</td></tr>
         <tr><td><code>welcome</code></td><td>Default landing page</td></tr>
     </tbody>
 </table>

--- a/assets/php_framework/0030Basic_Concepts/0020trongates_directory_structure.html
+++ b/assets/php_framework/0030Basic_Concepts/0020trongates_directory_structure.html
@@ -17,12 +17,23 @@
 <p>Your app lives here. One folder per feature. No third-party code.  100% Native PHP.</p>
 [code]
 modules/
-  users/
-    Users.php              ← controller (the boss)
-    Users_model.php        ← optional
-    views/                 ← pure PHP (no template engine)
-      welcome.php
-      login.php
+  db/
+  file/
+  flashdata/
+  form/
+  image/
+  language/
+  pagination/
+  string_service/
+  templates/
+  trongate_administrators/
+  trongate_control/
+  trongate_security/
+  trongate_tokens/
+  url/
+  utilities/
+  validation/
+  welcome/
 [/code]
 <p>Trongate ships with the following built-in modules:</p>
 

--- a/assets/php_framework/0030Basic_Concepts/0070loading_modules.html
+++ b/assets/php_framework/0030Basic_Concepts/0070loading_modules.html
@@ -36,7 +36,7 @@ class Members extends Trongate {
 $vat = $this-&gt;tax-&gt;calculate($amount);
 [/code]
 
-<p>Inside any view, use <span class="feature-ref">Modules::run()</span>:</p>
+<p>Inside any view, use <span class="feature-ref">class-modules-run()</span>:</p>
 [code=php]
 &lt;div&gt;&lt;?= Modules::run('users/stats', $user_data) ?&gt;&lt;/div&gt;
 [/code]
@@ -47,7 +47,7 @@ $vat = $this-&gt;tax-&gt;calculate($amount);
     <p>You're <em>very</em> welcome.</p>
 </div>
 
-<h2>Passing Data? Pass <strong>ANYTHING</strong>.</h2>
+<h2><span class="feature-ref">class-modules-run()</span> — Pass <strong>ANYTHING</strong>.</h2>
 
 <div class="alert alert-success">
     <p>The second parameter of <code>Modules::run()</code> accepts <strong>ANY PHP data type</strong>:</p>

--- a/assets/php_framework/0030Basic_Concepts/0070loading_modules.html
+++ b/assets/php_framework/0030Basic_Concepts/0070loading_modules.html
@@ -36,7 +36,7 @@ class Members extends Trongate {
 $vat = $this-&gt;tax-&gt;calculate($amount);
 [/code]
 
-<p>Inside any view, use <span class="feature-ref">class-modules-run()</span>:</p>
+<p>Inside any view, use <span class="feature-ref">class_reference-the_modules_class-run()</span>:</p>
 [code=php]
 &lt;div&gt;&lt;?= Modules::run('users/stats', $user_data) ?&gt;&lt;/div&gt;
 [/code]
@@ -47,7 +47,7 @@ $vat = $this-&gt;tax-&gt;calculate($amount);
     <p>You're <em>very</em> welcome.</p>
 </div>
 
-<h2><span class="feature-ref">class-modules-run()</span> — Pass <strong>ANYTHING</strong>.</h2>
+<h2><span class="feature-ref">class_reference-the_modules_class-run()</span> — Pass <strong>ANYTHING</strong>.</h2>
 
 <div class="alert alert-success">
     <p>The second parameter of <code>Modules::run()</code> accepts <strong>ANY PHP data type</strong>:</p>

--- a/assets/php_framework/0045Intercepting_Requests/0030preventing_url_invocation.html
+++ b/assets/php_framework/0045Intercepting_Requests/0030preventing_url_invocation.html
@@ -104,7 +104,7 @@ class Payment extends Trongate {
 
 <div class="alert alert-info">
     <p><strong>PRO-TIP: Avoiding "Ghost" 403 Errors</strong></p>
-    <p>If you are blocking an entire module inside a constructor, it is best practice to use a <b>literal string</b> (e.g., <code>block_url('tasks');</code>) rather than a dynamic variable.</p>
+    <p>If you are blocking an entire module inside a constructor, it is best practice to use a <b>literal string</b> (e.g., <code>block_url('payment');</code>) rather than a dynamic variable.</p>
     <p class="mb-0">This ensures that if your module is ever loaded as a service by another controller, you don't accidentally block the caller's URL. For more details on how modules interact, see <a href="documentation/mastering-constructors">Mastering Constructors</a>.</p>
 </div>
 
@@ -119,7 +119,7 @@ class Payment extends Trongate {
 
 <div class="alert alert-info">
     <p class="mb-0">
-        The constructor code, used in the example above, will work in most cases.  However, there are edge cases where different syntax would be required for invoking a constructor. For a full explanation, see 
+        The constructor code in the example above follows the recommended pattern. A full explanation of constructors in Trongate v2 can be found at
         <a href="documentation/trongate_php_framework/tips-and-best-practices/mastering-constructors" target="_blank">Mastering Constructors</a>.
     </p>
 </div>

--- a/assets/reference/class_reference/the_modules_class/run.html
+++ b/assets/reference/class_reference/the_modules_class/run.html
@@ -1,0 +1,84 @@
+<div class="container">
+  <h1>run()</h1>
+  <p class="signature">public static function run(string $module_method, mixed $data = null): mixed</p>
+
+  <h2>Description</h2>
+  <div class="description">
+    <p>Executes a module controller method from anywhere — controllers, views, or models — by passing the module/method string and optional data. Accepts any PHP data type as the second parameter.</p>
+  </div>
+
+  <h2>Parameters</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Parameter</th>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>$module_method</td>
+        <td>string</td>
+        <td>The target module and method in "Module/Method" format (e.g. <code>'users/stats'</code>)</td>
+      </tr>
+      <tr>
+        <td>$data</td>
+        <td>mixed</td>
+        <td>(optional) Data to pass to the target method. Accepts any PHP type: strings, integers, arrays, objects, booleans, or null.</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>Return Value</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>mixed</td>
+        <td>Returns whatever the target method returns. No type restriction.</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>Example #1: Passing a String</h2>
+[code=php]
+$result = Modules::run('email/send', 'john@example.com');
+[/code]
+
+  <h2>Example #2: Passing an Integer</h2>
+[code=php]
+$profile = Modules::run('users/get_profile', 88);
+[/code]
+
+  <h2>Example #3: Passing an Array</h2>
+[code=php]
+$order_data = [
+    'order_id' => 12345,
+    'customer' => 'Jane Smith',
+    'items' => [
+        ['id' => 1, 'qty' => 2, 'price' => 19.99]
+    ]
+];
+$invoice = Modules::run('orders/generate_invoice', $order_data);
+[/code]
+
+  <h2>Example #4: Passing null</h2>
+[code=php]
+$default_view = Modules::run('dashboard/load_default', null);
+[/code]
+
+  <h2>Notes</h2>
+  <ul>
+    <li>The <code>Modules::run()</code> method is callable from controllers, views, and models</li>
+    <li>The first parameter must be in <code>Module/Method</code> format — case-insensitive for both segments</li>
+    <li>If the target module is a child module, use hyphenated format: <code>'parent-child/method'</code></li>
+    <li>When <code>$data</code> is null, the target method is called without parameters</li>
+    <li>Throws <code>Exception</code> if the controller or method is not found</li>
+  </ul>
+</div>


### PR DESCRIPTION
The example code block under `modules/` showed a fictitious `users/` module. Replaced with the actual 17 modules that ship with Trongate v2 (validacious edition), matching https://github.com/trongate/trongate-framework/tree/master/modules