### PR TITLE
Updated documentation for new login module architecture

### DIFF
--- a/assets/php_framework/0030Basic_Concepts/0011everything_is_a_module.html
+++ b/assets/php_framework/0030Basic_Concepts/0011everything_is_a_module.html
@@ -43,7 +43,9 @@ modules/
         <tr><td><code>pagination</code></td><td>Page navigation for result sets</td></tr>
         <tr><td><code>string_service</code></td><td>String manipulation helpers (truncate, split, filter)</td></tr>
         <tr><td><code>templates</code></td><td>Admin and public page rendering with layout support</td></tr>
-        <tr><td><code>trongate_administrators</code></td><td>Admin authentication and access control</td></tr>
+        <tr><td><code>login</code></td><td>Universal login for any user table</td></tr>
+        <tr><td><code>trongate_administrators</code></td><td>Admin panel (create, edit, delete users)</td></tr>
+        <tr><td><code>trongate_email</code></td><td>Send emails via SMTP</td></tr>
         <tr><td><code>trongate_control</code></td><td>Module management and SQL import</td></tr>
         <tr><td><code>trongate_security</code></td><td>Permission checking, method-level access control</td></tr>
         <tr><td><code>trongate_tokens</code></td><td>API token generation, validation, lifecycle</td></tr>

--- a/assets/php_framework/0030Basic_Concepts/0020trongates_directory_structure.html
+++ b/assets/php_framework/0030Basic_Concepts/0020trongates_directory_structure.html
@@ -23,11 +23,13 @@ modules/
   form/
   image/
   language/
+  login/
   pagination/
   string_service/
   templates/
   trongate_administrators/
   trongate_control/
+  trongate_email/
   trongate_security/
   trongate_tokens/
   url/
@@ -54,7 +56,9 @@ modules/
         <tr><td><code>pagination</code></td><td>Page navigation</td></tr>
         <tr><td><code>string_service</code></td><td>String manipulation</td></tr>
         <tr><td><code>templates</code></td><td>Admin and public page rendering</td></tr>
-        <tr><td><code>trongate_administrators</code></td><td>Admin authentication</td></tr>
+        <tr><td><code>login</code></td><td>Universal login for any user table</td></tr>
+        <tr><td><code>trongate_administrators</code></td><td>Admin panel (create, edit, delete users)</td></tr>
+        <tr><td><code>trongate_email</code></td><td>Send emails via SMTP</td></tr>
         <tr><td><code>trongate_control</code></td><td>Module management and SQL import</td></tr>
         <tr><td><code>trongate_security</code></td><td>Permission checking</td></tr>
         <tr><td><code>trongate_tokens</code></td><td>API token generation and validation</td></tr>

--- a/assets/php_framework/0040Understanding_Routing/0030hiding_the_admin_login_url.html
+++ b/assets/php_framework/0040Understanding_Routing/0030hiding_the_admin_login_url.html
@@ -1,73 +1,36 @@
-[meta-description]Hide your Trongate admin login in seconds: pick a secret word, update two lines in custom_routing.php and one in the admin controller. Default URLs die, hackers cry. Security done.[/meta-description]
-<h1>Hiding The Admin Login URL</h1>
+[meta-description]Trongate's login module uses a public, discoverable login URL — security through strong authentication, not obscurity. Learn why this is more secure and how it works.[/meta-description]
+<h1>Hiding The Admin Login URL &mdash; Deprecated</h1>
 
-<p>When you initially install Trongate, your admin login URL is:</p>
-[code]https://yoursite.com/trongate_administrators/login[/code]
+<div class="alert alert-warning">
+    <p><strong>Note:</strong> This technique belongs to older versions of Trongate. The <code>login</code> module (shipped with Trongate v2) replaces this approach entirely. Security through obscurity is no longer recommended &mdash; the login module is secure by design.</p>
+</div>
 
-<p>The following shorter URL also works:</p>
-[code]https://yoursite.com/tg-admin[/code]
+<h2>The Old Approach</h2>
+<p>In previous versions of Trongate, the <code>trongate_administrators</code> module featured a configurable <code>$secret_login_segment</code> property. Administrators could set a private word that acted as the login URL, making it harder for attackers to find the login page. Custom routing mapped this secret word to <code>trongate_administrators/login</code>.</p>
 
-<p><strong><span style="color: red;">Hackers know this.</span></strong>  You do not want them knocking.</strong></p>
+<p>However, this approach had a known vulnerability: an unauthenticated request to <code>trongate_administrators/logout</code> would redirect to the secret login URL, revealing it in the HTTP response headers. The secret was exposed to anyone who knew where to look.</p>
 
-<p><strong>So, let us fix it.</strong></p>
-<hr>
-
-<h2 class="mt-0">Step 1: Pick your secret word</h2>
-
-<p>Choose something random but memorable. No spaces. No special characters. Use a single, made-up word that you can remember.</p>
-
-<p>Example:</p>
-[code]fantasticola[/code]
-
-<p>Your new admin login URL becomes:</p>
-[code]https://yoursite.com/fantasticola[/code]
-
-<hr>
-
-<h2 class="mt-0">Step 2: Update custom routing</h2>
-
-<p>Open <code>config/custom_routing.php</code>. You should see something like this:</p>
-
-[code=php]&lt;?php
-$routes = [
-    'tg-admin' => 'trongate_administrators/login',
-    'tg-admin/submit_login' => 'trongate_administrators/submit_login'
-];
-define('CUSTOM_ROUTES', $routes);
-[/code]
-
-<p>Replace <strong>both</strong> occurrences of <code>tg-admin</code> with your secret word. For example:</p>
-
-[code=php]&lt;?php
-$routes = [
-    "fantasticola" =&gt; "trongate_administrators/login",
-    "fantasticola/submit_login" =&gt; "trongate_administrators/submit_login"
-];
-define("CUSTOM_ROUTES", $routes);
-[/code]
-
-<hr>
-
-<h2 class="mt-0">Step 3: Lock the back door</h2>
-
-<p>Open:</p> 
-[code]modules/trongate_administrators/Trongate_administrators.php[/code]
-
-<p>Around line 12 you will see this commented line:</p>
-
-[code=php]//private $secret_login_segment = "tg-admin";[/code]
-
-<p>Uncomment it and replace <code>tg-admin</code> with your secret word:</p>
-
-[code=php]private $secret_login_segment = "fantasticola";[/code]
-
-<hr>
-
-<h2 class="mt-0">Congratulations!</h2>
-
-<p>Now:</p>
+<h2>Why We Changed</h2>
+<p>The new <code>login</code> module takes a fundamentally different approach. Instead of hiding the login URL, it focuses on proper security controls:</p>
 <ul>
-    <li><code>trongate_administrators/login</code>  -  returns <strong>404</strong>.</li>
-    <li><code>tg-admin</code>  -  <strong>no longer works</strong>.</li>
-    <li>Only your secret URL (<code>fantasticola</code>) grants access.</li>
+    <li><strong>Timing-safe password verification</strong> &mdash; Prevents enumeration attacks by always using a valid bcrypt hash, even when the username does not exist</li>
+    <li><strong>Brute-force protection</strong> &mdash; Configurable rate limiting tracks failed attempts by both identifier and IP address, blocking access after a configurable number of failures</li>
+    <li><strong>Dedicated login_attempts table</strong> &mdash; Failed attempts are tracked independently of user records, so even non-existent usernames are rate-limited</li>
+    <li><strong>Configurable user levels</strong> &mdash; Support for multiple user tables (administrators, members, etc.) from a single module</li>
+    <li><strong>Multi-identifier login</strong> &mdash; Users can log in with any configured identifier (username, email, or both)</li>
+</ul>
+
+<h2>How It Works Now</h2>
+<p>The login module is accessed at the public URL <code>login/login</code>. A discoverable, well-audited login page with proper security controls is far more robust than a hidden one that can be leaked through redirects.</p>
+
+<h2>Migrating to the New System</h2>
+<p>If you are upgrading an existing project, please refer to the <a href="documentation/trongate_php_framework/tips-and-best-practices/migrating-to-the-universal-login-module">Migrating to the Universal Login Module</a> guide for step-by-step instructions.</p>
+
+<h2>Benefits of the New Approach</h2>
+<ul>
+    <li><strong>No secret URLs to leak</strong> &mdash; Security is built into the authentication process, not the URL</li>
+    <li><strong>Proper rate limiting</strong> &mdash; Blocks brute-force attempts regardless of whether the username exists</li>
+    <li><strong>Consistent authentication</strong> &mdash; All user types authenticate through the same robust system</li>
+    <li><strong>Forgot password flow</strong> &mdash; Built-in password reset with SMTP-based email delivery</li>
+    <li><strong>Configurable</strong> &mdash; Adjust security settings without touching code</li>
 </ul>

--- a/assets/php_framework/0050Module_Fundamentals/0070importing_sql.html
+++ b/assets/php_framework/0050Module_Fundamentals/0070importing_sql.html
@@ -122,7 +122,7 @@
 
 [code]// config/custom_routing.php
 $routes = [
-    'admin' => 'trongate_administrators/login'
+    'admin' => 'login/login'
 ];[/code]
 
 <p>Visiting <code>/admin</code> triggers Trongate Control for <code>trongate_administrators</code>. After SQL execution and version checks, you return to <code>/admin</code>.</p>

--- a/assets/php_framework/0050Module_Fundamentals/0080introducing_included_modules.html
+++ b/assets/php_framework/0050Module_Fundamentals/0080introducing_included_modules.html
@@ -20,7 +20,8 @@
     <li><a href="documentation-ref/list_refs/included/pagination" target="_blank">pagination</a> ← beautiful links in 3 seconds</li>
     <li><a href="documentation-ref/list_refs/included/string_service" target="_blank">string_service</a> ← string manipulation made easy</li>
     <li><a href="documentation-ref/list_refs/included/templates" target="_blank">templates</a> ← layouts &amp; partials</li>
-    <li><a href="documentation-ref/list_refs/included/trongate_administrators" target="_blank">trongate_administrators</a> ← full admin panel</li>
+    <li><a href="documentation-ref/list_refs/included/trongate_administrators" target="_blank">trongate_administrators</a> ← admin panel (create, edit, delete users)</li>
+    <li><a href="documentation-ref/list_refs/included/trongate_email" target="_blank">trongate_email</a> ← send HTML and plain text emails via SMTP</li>
     <li><a href="documentation-ref/list_refs/included/trongate_control" target="_blank">trongate_control</a> ← inspect running modules</li>
     <li><a href="documentation-ref/list_refs/included/trongate_security" target="_blank">trongate_security</a> ← CSRF, XSS, headers, the works</li>
     <li><a href="documentation-ref/list_refs/included/trongate_tokens" target="_blank">trongate_tokens</a> ← one-time tokens</li>

--- a/assets/php_framework/0140Security/0060the_trongate_security_module.html
+++ b/assets/php_framework/0140Security/0060the_trongate_security_module.html
@@ -29,12 +29,12 @@ $this-&gt;trongate_security-&gt;make_sure_allowed('scenario_name');
 <p>Each scenario routes to a specific module that knows how to handle that particular type of access control.</p>
 
 <div class="alert alert-info">
-    <p>It's for you - the developer - to decide how many scenarios your application is going to have. You also, as the developer, determine what names each scenario should be given.</p>
+    <p>It is for you — the developer — to decide how many scenarios your application is going to have. You also, as the developer, determine what names each scenario should be given.</p>
 </div>
 
 <h2>How It Works</h2>
 
-<p>The <code>Trongate_security</code> module uses a switch statement to delegate scenarios to appropriate modules:</p>
+<p>The <code>Trongate_security</code> module uses a switch statement to delegate scenarios to appropriate modules. The default scenario handles admin panel access by checking for a valid token with user level 1:</p>
 
 [code=php]
 &lt;?php
@@ -53,8 +53,19 @@ class Trongate_security extends Trongate {
                 
             default:
                 // Default: admin panel access
-                $result = $this-&gt;trongate_administrators-&gt;make_sure_allowed();
-                return $result;
+                // Checks for a valid token for user level 1 (administrators)
+                $token = $this-&gt;trongate_tokens-&gt;attempt_get_valid_token(1);
+                
+                if ($token === false) {
+                    if (ENV === 'dev') {
+                        // Dev mode convenience: create a token and redirect to login
+                        redirect('login/login');
+                    } else {
+                        redirect('login/login');
+                    }
+                }
+                
+                return $token;
         }
     }
 }
@@ -64,9 +75,11 @@ class Trongate_security extends Trongate {
     <p>The commented-out case shows how to add custom scenarios. Uncomment and modify as needed for your application.</p>
 </div>
 
+<p>In development mode (<code>ENV === 'dev'</code>), the login module provides convenience features to streamline development. In production, unauthenticated users are always redirected to the login page at <code>login/login</code>.</p>
+
 <h2>The Default Scenario</h2>
 
-<p>If you don't specify a scenario, it defaults to <code>'admin panel'</code>:</p>
+<p>If you do not specify a scenario, it defaults to <code>'admin panel'</code>:</p>
 
 [code=php]
 // These two calls are identical
@@ -74,25 +87,18 @@ $this-&gt;trongate_security-&gt;make_sure_allowed();
 $this-&gt;trongate_security-&gt;make_sure_allowed('admin panel');
 [/code]
 
-<p>Both delegate to <code>trongate_administrators-&gt;make_sure_allowed()</code>, which:</p>
-
-<ol>
-    <li>Checks for a valid token with user level 1 (admin)</li>
-    <li>In dev mode: auto-generates a token for convenience</li>
-    <li>In production: redirects to login if no valid token</li>
-    <li>Returns the token string if successful</li>
-</ol>
+<p>Both check for a valid token with user level 1 (administrators) and redirect to <code>login/login</code> if none is found.</p>
 
 <h2>Return Values: Flexible by Design</h2>
 
 <p>The <span class="feature-ref">make_sure_allowed()</span> method is intentionally open-ended. It can return:</p>
 
 <ul>
-    <li><strong>String</strong> - The validated token</li>
-    <li><strong>Boolean</strong> - <code>true</code> for public access, <code>false</code> for denied</li>
-    <li><strong>Object</strong> - Complete user object with permissions</li>
-    <li><strong>Array</strong> - Custom data structure with multiple values</li>
-    <li><strong>Nothing</strong> - Can redirect or die instead of returning</li>
+    <li><strong>String</strong> — The validated token</li>
+    <li><strong>Boolean</strong> — <code>true</code> for public access, <code>false</code> for denied</li>
+    <li><strong>Object</strong> — Complete user object with permissions</li>
+    <li><strong>Array</strong> — Custom data structure with multiple values</li>
+    <li><strong>Nothing</strong> — Can redirect or die instead of returning</li>
 </ul>
 
 <p>The return type depends on what your scenario needs. You decide.</p>
@@ -103,14 +109,14 @@ $this-&gt;trongate_security-&gt;make_sure_allowed('admin panel');
 
 <h2>Example: Discussion Forum</h2>
 
-<p>Let's build a hypothetical discussion forum accessible by the public, with special privileges for admin users and member users.</p>
+<p>Let us build a hypothetical discussion forum accessible by the public, with special privileges for admin users and member users.</p>
 
 <h3>The Requirements</h3>
 
 <ul>
-    <li><strong>Read comments</strong> - Open to anyone (no authentication)</li>
-    <li><strong>Create comments</strong> - Must be a logged-in member</li>
-    <li><strong>Edit/delete comments</strong> - Must be the comment owner OR an admin</li>
+    <li><strong>Read comments</strong> — Open to anyone (no authentication)</li>
+    <li><strong>Create comments</strong> — Must be a logged-in member</li>
+    <li><strong>Edit/delete comments</strong> — Must be the comment owner OR an admin</li>
 </ul>
 
 <h3>Trongate_security.php</h3>
@@ -121,14 +127,14 @@ $this-&gt;trongate_security-&gt;make_sure_allowed('admin panel');
 public function make_sure_allowed(string $scenario = 'admin panel', array $params = []): mixed {
     switch ($scenario) {
         case 'read comment':
-            // Public access - no authentication required
+            // Public access — no authentication required
             return true;
             
         case 'create comment':
             // Must be a member (user level 2)
             $token = $this-&gt;trongate_tokens-&gt;attempt_get_valid_token(2);
             if ($token === false) {
-                redirect('members/login');
+                redirect('login/login');
             }
             return $token;
             
@@ -139,9 +145,14 @@ public function make_sure_allowed(string $scenario = 'admin panel', array $param
             return $result;
             
         default:
-            // Admin panel access
-            $result = $this-&gt;trongate_administrators-&gt;make_sure_allowed();
-            return $result;
+            // Admin panel access — checks for user level 1 token
+            $token = $this-&gt;trongate_tokens-&gt;attempt_get_valid_token(1);
+            
+            if ($token === false) {
+                redirect('login/login');
+            }
+            
+            return $token;
     }
 }
 [/code]
@@ -169,7 +180,7 @@ public function make_sure_allowed(string $scenario = 'members area', array $para
             $user = $this-&gt;trongate_tokens-&gt;get_user_obj();
             
             if ($user === false) {
-                redirect('members/login');
+                redirect('login/login');
             }
             
             // Fetch comment
@@ -264,6 +275,21 @@ class Forum_comments extends Trongate {
     <p>This example assumes you have <code>public</code> and <code>members_area</code> templates created.</p>
 </div>
 
+<h2>Using $this->login->make_sure_allowed() Directly</h2>
+
+<p>In your own controllers, you can also call the login module directly to check authentication without going through the security module:</p>
+
+[code=php]
+// Check if the current user is logged in as an administrator (user level 1)
+$token = $this-&gt;login-&gt;make_sure_allowed();
+
+if ($token === false) {
+    redirect('login/login');
+}
+[/code]
+
+<p>The <code>login-&gt;make_sure_allowed()</code> method checks the token, validates the user level, and returns the token string if valid, or <code>false</code> if not. In development mode, it provides convenience features; in production, it always requires proper authentication.</p>
+
 <h2>The $params Array</h2>
 
 <p>The optional <code>$params</code> array allows fine-grained control:</p>
@@ -279,27 +305,6 @@ $this-&gt;trongate_security-&gt;make_sure_allowed('moderate forum', $params);
 [/code]
 
 <p>Pass any data your scenario needs to make authorization decisions.</p>
-
-<h2>Dev Mode Auto-Login</h2>
-
-<p>The <code>trongate_administrators</code> module includes special behavior for development:</p>
-
-[code=php]
-if ($token === false) {
-    if (ENV === 'dev') {
-        // Auto-generate token for first admin
-        // (convenience feature for development)
-    } else {
-        redirect('trongate_administrators/login');
-    }
-}
-[/code]
-
-<p>In dev mode, the first administrator is automatically logged in. This speeds up development by eliminating repeated logins.</p>
-
-<div class="alert alert-warning">
-    <p><strong>Production Safety:</strong> This auto-login only works when <code>ENV === 'dev'</code> in your config. Production deployments always require proper authentication.</p>
-</div>
 
 <h2>Building Your Own Scenarios</h2>
 
@@ -319,7 +324,7 @@ case 'premium content':
     $user = $this-&gt;trongate_tokens-&gt;get_user_obj();
     
     if ($user === false) {
-        redirect('members/login');
+        redirect('login/login');
     }
     
     // Check if user has premium subscription
@@ -336,11 +341,11 @@ case 'premium content':
 <h2>Why Scenarios Win</h2>
 
 <ul>
-    <li><strong>Centralized security logic</strong> - All authorization in one place</li>
-    <li><strong>Consistent patterns</strong> - Same method call everywhere</li>
-    <li><strong>Easy to audit</strong> - Review security in one file</li>
-    <li><strong>Flexible delegation</strong> - Complex logic lives in appropriate modules</li>
-    <li><strong>Testable</strong> - Mock scenarios for unit tests</li>
+    <li><strong>Centralized security logic</strong> — All authorization in one place</li>
+    <li><strong>Consistent patterns</strong> — Same method call everywhere</li>
+    <li><strong>Easy to audit</strong> — Review security in one file</li>
+    <li><strong>Flexible delegation</strong> — Complex logic lives in appropriate modules</li>
+    <li><strong>Testable</strong> — Mock scenarios for unit tests</li>
 </ul>
 
 <h2>Common Patterns</h2>
@@ -358,7 +363,7 @@ case 'public page':
 case 'members area':
     $token = $this-&gt;trongate_tokens-&gt;attempt_get_valid_token(2);
     if ($token === false) {
-        redirect('members/login');
+        redirect('login/login');
     }
     return $token;
 [/code]
@@ -373,10 +378,10 @@ case 'complex scenario':
 
 <div class="alert alert-success">
     <ul class="mt-0">
-        <li><strong>Use descriptive scenario names</strong> - <code>'edit comment'</code> not <code>'scenario_7'</code></li>
-        <li><strong>Delegate complex logic</strong> - Keep switch statement clean, push details to modules</li>
-        <li><strong>Return consistent types per scenario</strong> - Don't mix tokens and booleans for same scenario</li>
-        <li><strong>Document your scenarios</strong> - Add comments explaining what each scenario protects</li>
-        <li><strong>Test thoroughly</strong> - Especially ownership checks and edge cases</li>
+        <li><strong>Use descriptive scenario names</strong> — <code>'edit comment'</code> not <code>'scenario_7'</code></li>
+        <li><strong>Delegate complex logic</strong> — Keep switch statement clean, push details to modules</li>
+        <li><strong>Return consistent types per scenario</strong> — Do not mix tokens and booleans for same scenario</li>
+        <li><strong>Document your scenarios</strong> — Add comments explaining what each scenario protects</li>
+        <li><strong>Test thoroughly</strong> — Especially ownership checks and edge cases</li>
     </ul>
 </div>

--- a/assets/php_framework/0200Tips_And_Best_Practices/0020migrating_to_the_universal_login_module.html
+++ b/assets/php_framework/0200Tips_And_Best_Practices/0020migrating_to_the_universal_login_module.html
@@ -47,16 +47,6 @@ $config['login'] = [
     'password_hash_cost' =&gt; 11,
     'default_view_file' =&gt; 'login_compact',
 
-    'smtp' =&gt; [
-        'host' =&gt; '',
-        'port' =&gt; '587',
-        'username' =&gt; '',
-        'password' =&gt; '',
-        'encryption' =&gt; 'tls',
-        'from_email' =&gt; '',
-        'from_name' =&gt; ''
-    ],
-
     'reset_token_lifespan' =&gt; 3600,
 
     'user_levels' =&gt; [
@@ -195,7 +185,7 @@ $config['login'] = [
     <li><strong>Multi-table support</strong> &mdash; Authenticate against any user table, not just <code>trongate_administrators</code></li>
     <li><strong>Multi-identifier login</strong> &mdash; Users can log in with their username, email address, or any combination defined in your config</li>
     <li><strong>Configurable view styles</strong> &mdash; Choose from three different login page layouts</li>
-    <li><strong>Forgot password flow</strong> &mdash; Built-in password reset with SMTP-based email delivery and token-based reset links</li>
+    <li><strong>Forgot password flow</strong> &mdash; Built-in password reset with email delivery via the <code>trongate_email</code> module and token-based reset links</li>
     <li><strong>Brute-force protection</strong> &mdash; Configurable rate limiting and failed-attempt tracking</li>
     <li><strong>Timing-safe hash comparison</strong> &mdash; Protection against timing-based enumeration attacks</li>
     <li><strong>No secret URLs</strong> &mdash; The system is secure by design, not by obscurity</li>


### PR DESCRIPTION
Updated framework documentation to reflect the transition from trongate_administrators-based authentication to the new login module.

## Changes

### Updated pages (7 files):

- **0040Understanding_Routing/0030hiding_the_admin_login_url.html** — Replaced old 'hide your admin URL' tutorial with deprecation notice explaining why the login module's public URL approach is more secure
- **0140Security/0060the_trongate_security_module.html** — Updated all code examples to use login/login redirects and token-checking patterns instead of trongate_administrators references
- **0200Tips_And_Best_Practices/0020migrating_to_the_universal_login_module.html** — Removed old smtp config from example code; updated SMTP reference to note trongate_email module
- **0030Basic_Concepts/0011everything_is_a_module.html** — Added login and trongate_email to module table; updated trongate_administrators description
- **0030Basic_Concepts/0020trongates_directory_structure.html** — Same table/directory listing updates
- **0050Module_Fundamentals/0080introducing_included_modules.html** — Added login and trongate_email to included modules list
- **0050Module_Fundamentals/0070importing_sql.html** — Updated routing example from trongate_administrators/login to login/login