### PR TITLE
Replaced deprecated 'hiding admin login' pages with production-ready content

### DIFF
--- a/assets/php_framework/0040Understanding_Routing/0030hiding_the_admin_login_url.html
+++ b/assets/php_framework/0040Understanding_Routing/0030hiding_the_admin_login_url.html
@@ -1,36 +1,148 @@
-[meta-description]Trongate's login module uses a public, discoverable login URL — security through strong authentication, not obscurity. Learn why this is more secure and how it works.[/meta-description]
-<h1>Hiding The Admin Login URL &mdash; Deprecated</h1>
+[meta-description]Configure custom login routes for the Trongate login module. Set prettier login URLs, redirect to the login page when unauthenticated, and manage authenticated access to protected pages.[/meta-description]
+<h1>Working with Login Routes</h1>
 
-<div class="alert alert-warning">
-    <p><strong>Note:</strong> This technique belongs to older versions of Trongate. The <code>login</code> module (shipped with Trongate v2) replaces this approach entirely. Security through obscurity is no longer recommended &mdash; the login module is secure by design.</p>
-</div>
+<p>The <code>login</code> module lives at the URL <code>login/login</code> by default. While this works fine, you may prefer a shorter or more branded path for your users &mdash; <code>/admin</code>, <code>/sign-in</code>, or anything else that suits your application.</p>
 
-<h2>The Old Approach</h2>
-<p>In previous versions of Trongate, the <code>trongate_administrators</code> module featured a configurable <code>$secret_login_segment</code> property. Administrators could set a private word that acted as the login URL, making it harder for attackers to find the login page. Custom routing mapped this secret word to <code>trongate_administrators/login</code>.</p>
+<p>This page covers how to configure custom routes for the login module and how to handle unauthenticated access to protected pages.</p>
 
-<p>However, this approach had a known vulnerability: an unauthenticated request to <code>trongate_administrators/logout</code> would redirect to the secret login URL, revealing it in the HTTP response headers. The secret was exposed to anyone who knew where to look.</p>
+<h2>The Default Login URL</h2>
 
-<h2>Why We Changed</h2>
-<p>The new <code>login</code> module takes a fundamentally different approach. Instead of hiding the login URL, it focuses on proper security controls:</p>
+<p>Out of the box, the login module is accessible at:</p>
+
+[code]https://yoursite.com/login/login[/code]
+
+<p>All login-related functionality sits under this module:</p>
+
+<table class="table sm">
+    <thead>
+        <tr>
+            <th>URL</th>
+            <th>Purpose</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr><td><code>login/login</code></td><td>Display the login form</td></tr>
+        <tr><td><code>login/logout</code></td><td>Log out the current user</td></tr>
+        <tr><td><code>login/forgot_password</code></td><td>Request a password reset</td></tr>
+        <tr><td><code>login/not_allowed</code></td><td>Access denied page</td></tr>
+        <tr><td><code>login/unlock</code></td><td>Unlock a blocked account</td></tr>
+    </tbody>
+</table>
+
+<h2>Setting a Custom Login URL</h2>
+
+<p>Open <code>config/custom_routing.php</code> and add a route that maps your preferred URL to the login module:</p>
+
+[code=php]
+&lt;?php
+$routes = [
+    'admin' => 'login/login',
+    'admin/submit_login' => 'login/submit_login'
+];
+define('CUSTOM_ROUTES', $routes);
+[/code]
+
+<p>Now, visiting <code>/admin</code> displays the login form, and the form submission is handled correctly through the custom route.</p>
+
+<h3>Including All Login Actions</h3>
+
+<p>If you want to route all login module actions under your custom path, add entries for each action:</p>
+
+[code=php]
+&lt;?php
+$routes = [
+    'admin' => 'login/login',
+    'admin/submit_login' => 'login/submit_login',
+    'admin/logout' => 'login/logout',
+    'admin/forgot_password' => 'login/forgot_password',
+    'admin/forgot_password/submit' => 'login/submit_forgot_password',
+    'admin/unlock' => 'login/unlock'
+];
+define('CUSTOM_ROUTES', $routes);
+[/code]
+
+<p>With these routes in place, your users see clean URLs like <code>/admin</code> and <code>/admin/logout</code> while the login module handles all the authentication logic behind the scenes.</p>
+
+<h2>Redirecting Unauthenticated Users to Login</h2>
+
+<p>When an unauthenticated user tries to access a protected page, the system needs to know where to send them. The login module handles this through the <code>redirect_on_success</code> and login-check methods, but you can also use Trongate's built-in <code>redirect()</code> helper:</p>
+
+[code=php]
+// In a protected controller method
+if (!$this-&gt;login-&gt;is_logged_in()) {
+    redirect('admin'); // Your custom login URL
+}
+[/code]
+
+<p>Alternatively, use the security module to let it handle redirection:</p>
+
+[code=php]
+$this-&gt;trongate_security-&gt;make_sure_allowed();
+// Redirects to login/login (or your custom route) if not authenticated
+[/code]
+
+<h2>The Security Module and Custom Routes</h2>
+
+<p>The <code>trongate_security</code> module's default scenario checks for a valid token and redirects to <code>login/login</code> if none is found. If you have set a custom route for login, the security module will still redirect correctly because the login module is doing the actual work.</p>
+
+<p>For scenarios where you need a different redirect behaviour, you can override the default scenario in your <code>Trongate_security.php</code> controller:</p>
+
+[code=php]
+switch ($scenario) {
+    default:
+        $token = $this-&gt;trongate_tokens-&gt;attempt_get_valid_token(1);
+
+        if ($token === false) {
+            redirect('admin'); // Custom login URL
+        }
+
+        return $token;
+}
+[/code]
+
+<h2>Configuration Options</h2>
+
+<p>The login module's behaviour is configured in <code>config/login.php</code>. The most relevant settings for routing are:</p>
+
+<table class="table sm">
+    <thead>
+        <tr>
+            <th>Setting</th>
+            <th>Purpose</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr><td><code>user_levels[x][redirect_on_success]</code></td><td>Where to send the user after a successful login</td></tr>
+        <tr><td><code>user_levels[x][view_file]</code></td><td>Which login view style to use (<code>login_default</code>, <code>login_compact</code>, or <code>login_split</code>)</td></tr>
+        <tr><td><code>max_failed_attempts</code></td><td>Number of failed attempts before blocking (default: 3)</td></tr>
+        <tr><td><code>block_duration</code></td><td>How long to block after max failures (seconds, default: 900)</td></tr>
+    </tbody>
+</table>
+
+<h2>Practical Example: Admin Panel</h2>
+
+<p>A common setup is to use a custom route for the admin login and a separate route for the members area:</p>
+
+[code=php]
+&lt;?php
+$routes = [
+    // Admin login
+    'portal' => 'login/login',
+    'portal/submit_login' => 'login/submit_login',
+    'portal/logout' => 'login/logout',
+    'portal/unlock' => 'login/unlock',
+    'portal/forgot_password' => 'login/forgot_password',
+    'portal/forgot_password/submit' => 'login/submit_forgot_password'
+];
+define('CUSTOM_ROUTES', $routes);
+[/code]
+
+<p>With this configuration:</p>
 <ul>
-    <li><strong>Timing-safe password verification</strong> &mdash; Prevents enumeration attacks by always using a valid bcrypt hash, even when the username does not exist</li>
-    <li><strong>Brute-force protection</strong> &mdash; Configurable rate limiting tracks failed attempts by both identifier and IP address, blocking access after a configurable number of failures</li>
-    <li><strong>Dedicated login_attempts table</strong> &mdash; Failed attempts are tracked independently of user records, so even non-existent usernames are rate-limited</li>
-    <li><strong>Configurable user levels</strong> &mdash; Support for multiple user tables (administrators, members, etc.) from a single module</li>
-    <li><strong>Multi-identifier login</strong> &mdash; Users can log in with any configured identifier (username, email, or both)</li>
+    <li>Administrators visit <code>/portal</code> to log in</li>
+    <li>They are redirected to <code>trongate_administrators/manage</code> after successful login (as configured in <code>config/login.php</code>)</li>
+    <li>The logout link becomes <code>/portal/logout</code></li>
+    <li>The forgot-password flow runs through <code>/portal/forgot_password</code></li>
 </ul>
 
-<h2>How It Works Now</h2>
-<p>The login module is accessed at the public URL <code>login/login</code>. A discoverable, well-audited login page with proper security controls is far more robust than a hidden one that can be leaked through redirects.</p>
-
-<h2>Migrating to the New System</h2>
-<p>If you are upgrading an existing project, please refer to the <a href="documentation/trongate_php_framework/tips-and-best-practices/migrating-to-the-universal-login-module">Migrating to the Universal Login Module</a> guide for step-by-step instructions.</p>
-
-<h2>Benefits of the New Approach</h2>
-<ul>
-    <li><strong>No secret URLs to leak</strong> &mdash; Security is built into the authentication process, not the URL</li>
-    <li><strong>Proper rate limiting</strong> &mdash; Blocks brute-force attempts regardless of whether the username exists</li>
-    <li><strong>Consistent authentication</strong> &mdash; All user types authenticate through the same robust system</li>
-    <li><strong>Forgot password flow</strong> &mdash; Built-in password reset with SMTP-based email delivery</li>
-    <li><strong>Configurable</strong> &mdash; Adjust security settings without touching code</li>
-</ul>
+<p>This gives your application a clean, branded authentication experience without exposing the underlying module structure.</p>

--- a/assets/php_framework/0200Tips_And_Best_Practices/0010hiding_the_admin_login_url.html
+++ b/assets/php_framework/0200Tips_And_Best_Practices/0010hiding_the_admin_login_url.html
@@ -1,26 +1,144 @@
-[meta-description]The Universal Login Module replaces the old secret login URL approach. Learn why public login URLs are more secure and how the new system works.[/meta-description]
-<h1>Hiding The Admin Login URL &mdash; Deprecated</h1>
+[meta-description]Set up the forgot-password feature in the Trongate login module. Configure the trongate_email module for SMTP delivery and enable password resets for any user level.[/meta-description]
+<h1>Setting Up Password Resets</h1>
 
-<div class="alert alert-warning">
-    <p><strong>Note:</strong> This page describes a technique used by previous versions of Trongate. The Universal Login Module (shipped with Trongate v2) replaces this approach entirely. Security through obscurity is no longer recommended &mdash; the new login module is secure by design.</p>
-</div>
+<p>The <code>login</code> module includes a built-in forgot-password flow. When a user forgets their password, they can request a reset link, which is sent to their email address via the <code>trongate_email</code> module.</p>
 
-<h2>The Old Approach</h2>
-<p>In previous versions of Trongate, the <code>trongate_administrators</code> module featured a configurable <code>$secret_login_segment</code> property. Administrators could set a private word that acted as the login URL, making it harder for attackers to find the login page. Custom routing mapped this secret word to <code>trongate_administrators/login</code>.</p>
+<p>This page walks through the complete setup.</p>
 
-<p>However, this approach had a known vulnerability: an unauthenticated request to <code>trongate_administrators/logout</code> would redirect to the secret login URL, revealing it in the HTTP response headers. This meant the secret was exposed to anyone who knew where to look.</p>
+<h2>Prerequisites</h2>
 
-<h2>Why We Changed</h2>
-<p>The new Universal Login Module takes a different approach. Instead of hiding the login URL, it focuses on:</p>
 <ul>
-    <li><strong>Secure credential validation</strong> &mdash; Timing-safe hash comparison prevents enumeration attacks</li>
-    <li><strong>Brute-force protection</strong> &mdash; Configurable rate limiting blocks repeated failed attempts</li>
-    <li><strong>Configurable view styles</strong> &mdash; Three different login page layouts to suit your site's design</li>
-    <li><strong>Multi-table support</strong> &mdash; Authenticate administrators, members, or any user type from one module</li>
+    <li>The <code>login</code> module in your <code>modules/</code> directory (included with Trongate v2)</li>
+    <li>The <code>trongate_email</code> module in your <code>modules/</code> directory (included with Trongate v2)</li>
+    <li>A configured <code>trongate_email.php</code> config file</li>
+    <li>SMTP credentials for sending emails</li>
 </ul>
 
-<h2>How It Works Now</h2>
-<p>The login module is accessed at the public URL <code>login/login</code>. This is intentional &mdash; a discoverable, well-audited login page with proper security controls is more robust than a hidden one that can be leaked through a redirect.</p>
+<h2>Step 1: Configure the Email Module</h2>
 
-<h2>Migrating to the New System</h2>
-<p>If you are upgrading an existing project, please refer to the <a href="documentation/trongate_php_framework/tips-and-best-practices/migrating-to-the-universal-login-module">Migrating to the Universal Login Module</a> guide for step-by-step instructions.</p>
+<p>Create <code>config/trongate_email.php</code> with your SMTP server details:</p>
+
+[code=php]
+&lt;?php
+$config['trongate_email'] = [
+    'smtp_host' => 'mail.yourdomain.com',
+    'smtp_port' => 465,
+    'smtp_user' => 'noreply@yourdomain.com',
+    'smtp_pass' => 'your_password',
+    'smtp_secure' => 'ssl',
+    'smtp_from_name' => 'Your Website'
+];
+[/code]
+
+<p>Common SMTP configurations:</p>
+
+<table class="table sm">
+    <thead>
+        <tr>
+            <th>Provider</th>
+            <th>Host</th>
+            <th>Port</th>
+            <th>Security</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr><td>cPanel / Shared Hosting</td><td><code>mail.yourdomain.com</code></td><td>465</td><td><code>ssl</code></td></tr>
+        <tr><td>Gmail (App Password)</td><td><code>smtp.gmail.com</code></td><td>587</td><td><code>tls</code></td></tr>
+        <tr><td>Mailgun / SendGrid</td><td>As provided</td><td>587</td><td><code>tls</code></td></tr>
+    </tbody>
+</table>
+
+<h2>Step 2: Configure the Login Module</h2>
+
+<p>Open <code>config/login.php</code>. The forgot-password feature uses these settings:</p>
+
+[code=php]
+&lt;?php
+$config['login'] = [
+    'reset_token_lifespan' => 3600, // Reset link expires in 1 hour
+    'user_levels' => [
+        1 => [
+            'target_table' => 'trongate_administrators',
+            'fields' => [
+                'identifiers' => [
+                    'email' => [
+                        'column' => 'email',
+                        'label'  => 'Email'
+                    ]
+                ]
+            ]
+        ]
+    ]
+];
+[/code]
+
+<p>The <code>reset_token_lifespan</code> setting controls how long a reset link remains valid. The default is 3600 seconds (1 hour).</p>
+
+<div class="alert alert-info">
+    <p>For the forgot-password feature to work, at least one identifier in your configuration must use the email column from your user table. Without an email identifier, the system cannot determine where to send the reset link.</p>
+</div>
+
+<h2>Step 3: Test the Forgot Password Flow</h2>
+
+<p>Navigate to the forgot-password form at:</p>
+
+[code]https://yoursite.com/login/forgot_password[/code]
+
+<ol>
+    <li>Enter the email address associated with the user account</li>
+    <li>Submit the form</li>
+    <li>Check the inbox for the reset email</li>
+    <li>Click the reset link and set a new password</li>
+</ol>
+
+<p>If you have configured custom routes (see <a href="documentation/trongate_php_framework/understanding-routing/working-with-login-routes">Working with Login Routes</a>), adjust the URL accordingly.</p>
+
+<h2>How It Works</h2>
+
+<p>When a user requests a password reset:</p>
+
+<ol>
+    <li>The login module looks up the user by email address in the configured target table</li>
+    <li>A cryptographically random token is generated and stored in the <code>trongate_tokens</code> table</li>
+    <li>An email is sent via <code>trongate_email</code> containing a reset link with the token</li>
+    <li>The user clicks the link and sets a new password</li>
+    <li>All existing authentication tokens for that user are destroyed, forcing a re-login everywhere</li>
+</ol>
+
+<p>This last step is critical for security &mdash; if an attacker had access to an active session, changing the password invalidates all sessions immediately.</p>
+
+<h2>Customising the Reset Email</h2>
+
+<p>The forgot-password email is built by the <code>Login_model</code> and sent via <code>trongate_email</code>. The email contains:</p>
+
+<ul>
+    <li>A greeting</li>
+    <li>The reset link (with a time-sensitive token)</li>
+    <li>An expiry notice</li>
+    <li>A warning to ignore if not requested</li>
+</ul>
+
+<p>The email is sent as an HTML-formatted message. The <code>trongate_email</code> module automatically generates a plain-text version from the HTML.</p>
+
+<h2>Troubleshooting</h2>
+
+<h3>Email Not Received</h3>
+<ul>
+    <li>Check that <code>config/trongate_email.php</code> exists and has valid SMTP credentials</li>
+    <li>Verify the SMTP host and port are correct for your provider</li>
+    <li>Check your server allows outbound connections on the SMTP port</li>
+    <li>Check spam folders</li>
+    <li>Test the SMTP configuration separately using the <code>trongate_email</code> module</li>
+</ul>
+
+<h3>Reset Link Expires Immediately</h3>
+<ul>
+    <li>Check that server time is accurate (clock drift can cause tokens to be considered expired)</li>
+    <li>Increase <code>reset_token_lifespan</code> in <code>config/login.php</code></li>
+</ul>
+
+<h3>User Not Found</h3>
+<ul>
+    <li>Verify the email identifier column matches your database column name</li>
+    <li>Check that the user level ID in the config matches the user's level</li>
+</ul>


### PR DESCRIPTION
Replaced two old pages that documented the deprecated trongate_administrators login approach with production-ready documentation for the current login module.

## Changes

### 0040Understanding_Routing/0030hiding_the_admin_login_url.html
→ **'Working with Login Routes'** — how to configure custom login URLs via routing, redirect unauthenticated users, and practical admin panel setup examples.

### 0200Tips_And_Best_Practices/0010hiding_the_admin_login_url.html
→ **'Setting Up Password Resets'** — complete guide for configuring the forgot-password feature: SMTP setup in config/trongate_email.php, reset token lifespan, how the flow works, and troubleshooting.