### PR TITLE
Add password recovery page and revise Quick Start

### DIFF
--- a/assets/trongate_way/0021Understanding_Trongates_Login_System/0080password_recovery.html
+++ b/assets/trongate_way/0021Understanding_Trongates_Login_System/0080password_recovery.html
@@ -1,0 +1,139 @@
+[meta-description]How to recover or reset a lost password in Trongate v2. Works for administrators, members, and any user level - in dev mode or live.[/meta-description]
+<div class="container">
+  <h1>Password Recovery</h1>
+
+  <p>
+    If you have lost your password, do not worry. It happens to all of us. The important thing is that you can fix it.
+  </p>
+
+  <p>
+    When you created your administrator account (or any other user account on your Trongate site), your password was stored in a database table. For administrators, this is the <code>trongate_administrators</code> table. For other types of users &mdash; such as members &mdash; it would be whatever table you set up for them (for example, a table called <code>members</code>).
+  </p>
+
+  <p>
+    In every case, the password lives in a column called <code>password</code> (or whatever you named it in your configuration). The data in that column is scrambled &mdash; it is turned into a long, unreadable string using a process called bcrypt hashing. This is a good thing. It means that even if someone were to see your database, they would not be able to read your password.
+  </p>
+
+  <p>
+    But here is the good news: even though your password is scrambled, you can still create a new one. The rest of this page will show you how, step by step. The instructions work whether your website is running in development mode or in live/production mode, and they work for any user level &mdash; administrators, members, or any other type of user you have set up.
+  </p>
+
+  <div class="alert alert-info">
+    <p>
+      The method for recovering your password depends on whether your website is in <strong>development mode</strong> or <strong>live mode</strong>. This is controlled by the <code>ENV</code> constant inside your <code>config/config.php</code> file. If <code>ENV</code> is set to <code>'dev'</code>, your site is in development mode. Anything else means your site is in live mode. We will cover both scenarios on this page.
+    </p>
+  </div>
+
+  <h2>Development Mode</h2>
+
+  <div class="alert alert-info">
+    <p>The following instructions explain how to reset a Trongate Administrator's password when working in Development Mode.</p>
+  </div>
+
+  <h3>Resetting a Trongate Administrator Password When In Development Mode</h3>
+
+  <ol>
+    <li>
+      <p><strong>Navigate to <code>&lt;base-url&gt;trongate_administrators/manage</code>.</strong></p>
+      <p>This will take you directly to the administrator management page. Since your application is running in Development Mode, you will be taken straight to the page without needing to log in.</p>
+    </li>
+    <li>
+      <p><strong>Locate the account whose password you want to reset, then click View.</strong></p>
+      <p>You will see a list of all Trongate Administrator accounts for your application. Clicking View will open the Account Details page.</p>
+    </li>
+    <li>
+      <p><strong>On the Account Details page, click Edit.</strong></p>
+      <p>This will take you to the Update Record page. Near the top-right corner of the page, you will find the Update Password button.</p>
+    </li>
+    <li>
+      <p><strong>Click Update Password.</strong></p>
+      <p>You can now enter and save a new password for the selected administrator account.</p>
+    </li>
+  </ol>
+
+  <h2>Live Mode</h2>
+
+  <p>
+    When your website is in live mode (<code>ENV</code> is set to anything other than <code>'dev'</code>), you cannot simply browse to the admin panel without logging in. You will need to use the login module's built-in <strong>Forgot Password</strong> feature instead.
+  </p>
+
+  <p>
+    This feature allows a user to request a password reset email. They enter their email address, receive a link, and choose a new password &mdash; all without needing anyone else's help.
+  </p>
+
+  <h3>Step 1: Enable the Forgot Password Feature</h3>
+
+  <p>
+    By default, the forgot password feature is disabled for administrators. Open your <code>config/login.php</code> file and find the administrator user level (level 1). Change this:
+  </p>
+
+  <pre><code>'enable_forgot_password' =&gt; false</code></pre>
+
+  <p>to this:</p>
+
+  <pre><code>'enable_forgot_password' =&gt; true</code></pre>
+
+  <p>Save the file.</p>
+
+  <h3>Step 2: Configure Your Email Settings</h3>
+
+  <p>
+    The forgot password feature sends emails through the <code>trongate_email</code> module. This module needs to know your SMTP server details so it can deliver the reset emails.
+  </p>
+
+  <p>
+    Create a file at <code>config/trongate_email.php</code> with your SMTP credentials:
+  </p>
+
+  <pre><code>&lt;?php
+$config['trongate_email'] = [
+    'smtp_host'       =&gt; 'mail.yourdomain.com',
+    'smtp_port'       =&gt; 465,
+    'smtp_user'       =&gt; 'noreply@yourdomain.com',
+    'smtp_pass'       =&gt; 'your-password-here',
+    'smtp_secure'     =&gt; 'ssl',
+    'smtp_from_name'  =&gt; 'Your Website Name'
+];</code></pre>
+
+  <p>
+    Replace the values above with your actual SMTP details. Your web host or email provider can give you these settings.
+  </p>
+
+  <h3>Step 3: Use the Forgot Password Form</h3>
+
+  <p>
+    Once the configuration is ready, the forgot password link will appear on your login form automatically. A user can also visit the forgot password page directly at:
+  </p>
+
+  <pre><code>http://yoursite.com/login/forgot_password/{secret_word}</code></pre>
+
+  <p>For administrators, this would be:</p>
+
+  <pre><code>http://yoursite.com/login/forgot_password/tg-admin</code></pre>
+
+  <p>Here is how the full flow works:</p>
+
+  <ol>
+    <li>
+      <p><strong>User enters their email address.</strong></p>
+      <p>The login module checks whether an account with that email exists. If it does, a unique, time-sensitive reset token is created and stored in the database.</p>
+    </li>
+    <li>
+      <p><strong>An email is sent with a reset link.</strong></p>
+      <p>The link contains the reset token and looks something like this: <code>http://yoursite.com/login/reset_password/abc123...64characters</code>. This link expires after one hour.</p>
+    </li>
+    <li>
+      <p><strong>User clicks the link and chooses a new password.</strong></p>
+      <p>The login module verifies that the token is valid and has not expired. The user then types a new password and confirms it.</p>
+    </li>
+    <li>
+      <p><strong>The password is updated.</strong></p>
+      <p>The new password is hashed and saved to the database. All existing authentication tokens for that user are destroyed, which means any active sessions are logged out. The user can then log in with their new password.</p>
+    </li>
+  </ol>
+
+  <p>
+    That is all there is to it. The login module handles the token generation, email delivery, password hashing, and session cleanup automatically.
+  </p>
+
+</div>


### PR DESCRIPTION
Updates to the Understanding Trongate's Login System chapter (0021):

- **0080password_recovery.html** - New page covering password recovery in both Development Mode (4-step admin panel process) and Live Mode (forgot password feature with SMTP setup)
- **0020quick_start.html** - Revised to focus on the three basic questions (credentials, URL, forgot password) with a link to the password recovery page