### PR TITLE
Formatting and link fixes for login chapter (0021)

### DIFF
--- a/assets/trongate_way/0021Understanding_Trongates_Login_System/0010what_is_a_login_system.html
+++ b/assets/trongate_way/0021Understanding_Trongates_Login_System/0010what_is_a_login_system.html
@@ -38,7 +38,7 @@
       <strong>It checks your credentials.</strong> You give the website your username (or email) and your password. The website looks up your account and checks if the password is correct.
     </li>
     <li>
-      <strong>It remembers you.</strong> Once the website confirms it is really you, it creates a little "token" &mdash; like a digital hand stamp. Every time you visit a new page, the website checks for that hand stamp. If it is there, you are let in.
+      <strong>It remembers you.</strong> Once the website confirms it is really you, it creates a little "token"  -  like a digital hand stamp. Every time you visit a new page, the website checks for that hand stamp. If it is there, you are let in.
     </li>
     <li>
       <strong>It forgets you when you leave.</strong> When you click "log out", the hand stamp is removed. The next time you visit, you will need to log in again.
@@ -67,7 +67,7 @@
   <h2>What's Next</h2>
 
   <p>
-    In the next page, we will look at the pieces you need &mdash; the database tables and the configuration file &mdash; and explain each one simply.
+    In the next page, we will look at the pieces you need  -  the database tables and the configuration file  -  and explain each one simply.
   </p>
 
 </div>

--- a/assets/trongate_way/0021Understanding_Trongates_Login_System/0020quick_start.html
+++ b/assets/trongate_way/0021Understanding_Trongates_Login_System/0020quick_start.html
@@ -32,7 +32,7 @@
     Open your browser and go to:
   </p>
 
-  <pre><code>http://yoursite.com/tg-admin</code></pre>
+  [code]http://yoursite.com/tg-admin[/code]
 
   <p>
     Replace <code>yoursite.com</code> with your actual website address (for example, <code>http://localhost/myproject/tg-admin</code> if you are working locally).
@@ -54,18 +54,18 @@
 
   <ul>
     <li>
-      <strong>Check your database.</strong> Look in the <code>trongate_administrators</code> table to remind yourself of your username or email. Your password is scrambled and cannot be read, but you can <a href="#">create a new password</a>, if required.
+      <strong>Check your database.</strong> Look in the <code>trongate_administrators</code> table to remind yourself of your username or email. Your password is scrambled and cannot be read, but you can <a href="documentation/trongate_way/understanding-trongates-login-system/password-recovery">create a new password</a>, if required.
     </li>
   </ul>
 
   <div class="alert alert-success">
-    <p>For guidance on how to create a new password, please refer to <a href="#">Page-Title</a>.</p>
+    <p>For guidance on how to create a new password, please refer to <a href="documentation/trongate_way/understanding-trongates-login-system/password-recovery">Password Recovery</a>.</p>
   </div>
 
   <h2>That Is It</h2>
 
   <p>
-    You are now logged in. The login module handles everything else automatically &mdash; remembering you while you browse, logging you out when you click "log out", and blocking people who try too many wrong passwords.
+    You are now logged in. The login module handles everything else automatically  -  remembering you while you browse, logging you out when you click "log out", and blocking people who try too many wrong passwords.
   </p>
 
   <p>

--- a/assets/trongate_way/0021Understanding_Trongates_Login_System/0030the_pieces_you_need.html
+++ b/assets/trongate_way/0021Understanding_Trongates_Login_System/0030the_pieces_you_need.html
@@ -14,7 +14,7 @@
 
   <p>These tables are already in your database. You do not need to create them.</p>
 
-  <h3><code>trongate_user_levels</code> &mdash; The User Types</h3>
+  <h3><code>trongate_user_levels</code>  -  The User Types</h3>
 
   <p>
     This table lists the different kinds of users your website has. Each row is one "user level." For example:
@@ -29,7 +29,7 @@
     You can have as many levels as you need. A school website might have: 1 = Teachers, 2 = Students, 3 = Parents. Each level has its own settings.
   </p>
 
-  <h3><code>trongate_users</code> &mdash; The Master List</h3>
+  <h3><code>trongate_users</code>  -  The Master List</h3>
 
   <p>
     Every person who has an account on your website gets one row in this table. It is a simple list that says, "This person exists, and they belong to this user level." The actual details (name, email, password) live in a separate table.
@@ -39,7 +39,7 @@
     Think of it like a school register. The register (<code>trongate_users</code>) lists each student's name and student ID number. The detailed records (grades, address, phone number) are kept in a different folder.
   </p>
 
-  <h3><code>trongate_tokens</code> &mdash; The Hand Stamps</h3>
+  <h3><code>trongate_tokens</code>  -  The Hand Stamps</h3>
 
   <p>
     When a user logs in successfully, the login module creates a "token." A token is just a long, random string of letters and numbers. It is stored in this table and also in the user's browser (as a cookie or session).
@@ -52,14 +52,14 @@
   <h2>Your Custom Table</h2>
 
   <p>
-    This is the table you create yourself. It stores the actual details of your users. The table name can be anything you like &mdash; <code>members</code>, <code>teachers</code>, <code>customers</code>, <code>accounts</code> &mdash; whatever fits your project.
+    This is the table you create yourself. It stores the actual details of your users. The table name can be anything you like  -  <code>members</code>, <code>teachers</code>, <code>customers</code>, <code>accounts</code>  -  whatever fits your project.
   </p>
 
   <p>
     A typical members table looks like this:
   </p>
 
-  <pre><code>members
+  [code]members
 ├── id                 (unique number for each member)
 ├── username           (the member's display name)
 ├── email_address      (the member's email)
@@ -69,13 +69,13 @@
 ├── trongate_user_id   (links this row back to trongate_users)
 ├── date_created       (when they joined)
 ├── num_logins         (how many times they have logged in)
-└── code               (a random security string)</code></pre>
+└── code               (a random security string)[/code]
 
   <p>
     Here is the SQL to create this table:
   </p>
 
-  <pre><code>CREATE TABLE members (
+  [code=sql]CREATE TABLE members (
     id int(11) NOT NULL AUTO_INCREMENT,
     username varchar(55) DEFAULT NULL UNIQUE,
     email_address varchar(255) DEFAULT NULL,
@@ -88,10 +88,10 @@
     trongate_user_id int(11) NOT NULL,
     code varchar(16) NOT NULL,
     PRIMARY KEY (id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;</code></pre>
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;[/code]
 
   <p>
-    You can add more columns for your own needs &mdash; for example, a profile picture, a bio, or a phone number. The login module only needs the <code>password</code> column and the identifier columns (like <code>username</code> or <code>email_address</code>). Everything else is extra.
+    You can add more columns for your own needs  -  for example, a profile picture, a bio, or a phone number. The login module only needs the <code>password</code> column and the identifier columns (like <code>username</code> or <code>email_address</code>). Everything else is extra.
   </p>
 
   <h2>The Configuration File</h2>

--- a/assets/trongate_way/0021Understanding_Trongates_Login_System/0040your_first_configuration.html
+++ b/assets/trongate_way/0021Understanding_Trongates_Login_System/0040your_first_configuration.html
@@ -10,7 +10,7 @@
     Create a new file at <code>config/login.php</code> and add the following:
   </p>
 
-  <pre><code>&lt;?php
+  [code=php]&lt;?php
 $config['login'] = [
 
     // Global settings
@@ -66,7 +66,7 @@ $config['login'] = [
             ]
         ]
     ]
-];</code></pre>
+];[/code]
 
   <h2>What Each Setting Means</h2>
 

--- a/assets/trongate_way/0021Understanding_Trongates_Login_System/0050login_urls_and_routing.html
+++ b/assets/trongate_way/0021Understanding_Trongates_Login_System/0050login_urls_and_routing.html
@@ -16,8 +16,8 @@
     If your <code>config/login.php</code> does <strong>not</strong> have a <code>secret_login_word</code>, you can use the user level's ID number directly:
   </p>
 
-  <pre><code>http://yoursite.com/login/login/1   (for administrators)
-http://yoursite.com/login/login/2   (for members)</code></pre>
+  [code]http://yoursite.com/login/login/1   (for administrators)
+http://yoursite.com/login/login/2   (for members)[/code]
 
   <p>
     The first <code>login</code> is the module name. The second <code>login</code> is the method that shows the form. The number (<code>1</code> or <code>2</code>) tells the module which user level this form is for.
@@ -29,15 +29,15 @@ http://yoursite.com/login/login/2   (for members)</code></pre>
     If you set a <code>secret_login_word</code> in your configuration (like <code>tg-admin</code> or <code>member-login</code>), you can use that word in the URL:
   </p>
 
-  <pre><code>http://yoursite.com/login/login/tg-admin    (for administrators)
-http://yoursite.com/login/login/member-login (for members)</code></pre>
+  [code]http://yoursite.com/login/login/tg-admin    (for administrators)
+http://yoursite.com/login/login/member-login (for members)[/code]
 
   <p>
     The login module looks at that last part of the URL (<code>tg-admin</code> or <code>member-login</code>), finds it in your configuration, and knows which user level to use.
   </p>
 
   <p>
-    If a user level has a <code>secret_login_word</code>, you <strong>cannot</strong> use the number version of the URL. For example, if members have the secret word <code>member-login</code>, going to <code>/login/login/2</code> will show a 404 page. This is a security feature &mdash; it keeps your login URLs unpredictable.
+    If a user level has a <code>secret_login_word</code>, you <strong>cannot</strong> use the number version of the URL. For example, if members have the secret word <code>member-login</code>, going to <code>/login/login/2</code> will show a 404 page. This is a security feature  -  it keeps your login URLs unpredictable.
   </p>
 
   <h2>Making the URL Even Shorter (Custom Routing)</h2>
@@ -50,20 +50,20 @@ http://yoursite.com/login/login/member-login (for members)</code></pre>
     Create a file at <code>config/custom_routing.php</code> and add:
   </p>
 
-  <pre><code>&lt;?php
+  [code=php]&lt;?php
 $routes = [
     'member-login' => 'login/login/member-login',
     'tg-admin'     => 'login/login/tg-admin'
 ];
-define('CUSTOM_ROUTES', $routes);</code></pre>
+define('CUSTOM_ROUTES', $routes);[/code]
 
   <p>
     Now your users can visit:
   </p>
 
   <ul>
-    <li><code>http://yoursite.com/member-login</code> &mdash; the member login form</li>
-    <li><code>http://yoursite.com/tg-admin</code> &mdash; the admin login form</li>
+    <li><code>http://yoursite.com/member-login</code>  -  the member login form</li>
+    <li><code>http://yoursite.com/tg-admin</code>  -  the admin login form</li>
   </ul>
 
   <p>

--- a/assets/trongate_way/0021Understanding_Trongates_Login_System/0060after_they_log_in.html
+++ b/assets/trongate_way/0021Understanding_Trongates_Login_System/0060after_they_log_in.html
@@ -3,7 +3,7 @@
   <h1>After They Log In</h1>
 
   <p>
-    Great news! The login module handles all the hard parts &mdash; checking passwords, creating tokens, rate-limiting bad attempts, and remembering logged-in users. Your job now is to build the pages that members see after they log in.
+    Great news! The login module handles all the hard parts  -  checking passwords, creating tokens, rate-limiting bad attempts, and remembering logged-in users. Your job now is to build the pages that members see after they log in.
   </p>
 
   <p>
@@ -20,7 +20,7 @@
     Let us build that welcome page. First, the controller:
   </p>
 
-  <pre><code>&lt;?php
+  [code=php]&lt;?php
 class Members extends Trongate {
 
     /**
@@ -32,18 +32,18 @@ class Members extends Trongate {
         $this-&gt;templates-&gt;public($data);
     }
 
-}</code></pre>
+}[/code]
 
   <p>
     Then, create the view file at <code>modules/members/views/welcome.php</code>:
   </p>
 
-  <pre><code>&lt;h1&gt;Welcome!&lt;/h1&gt;
+  [code=html]&lt;h1&gt;Welcome!&lt;/h1&gt;
 
 &lt;p&gt;You are now logged in as a member of our site.&lt;/p&gt;
 
 &lt;p&gt;&lt;?= anchor('members/your_account', 'Your Account') ?&gt;&lt;/p&gt;
-&lt;p&gt;&lt;?= anchor('members/logout', 'Logout') ?&gt;&lt;/p&gt;</code></pre>
+&lt;p&gt;&lt;?= anchor('members/logout', 'Logout') ?&gt;&lt;/p&gt;[/code]
 
   <p>
     That is it. The <code>welcome()</code> method loads the welcome view inside the public template. Your members see a friendly message and links to their account or to log out.
@@ -55,10 +55,10 @@ class Members extends Trongate {
     Logging out is even simpler. Add a <code>logout()</code> method to your Members controller:
   </p>
 
-  <pre><code>public function logout(): void {
+  [code=php]public function logout(): void {
     $this-&gt;trongate_tokens-&gt;destroy();
     redirect('member-login');
-}</code></pre>
+}[/code]
 
   <p>
     That is three lines of code. It destroys the user's token (removes the "digital hand stamp") and sends them back to the login page.
@@ -74,7 +74,7 @@ class Members extends Trongate {
     Protecting a page is easy. You check if the user has a valid token. If they do not, you send them to the login page.
   </p>
 
-  <pre><code>public function your_account(): void {
+  [code=php]public function your_account(): void {
     $member_level_id = 2;
     $token = $this-&gt;trongate_tokens-&gt;attempt_get_valid_token($member_level_id);
 
@@ -82,19 +82,19 @@ class Members extends Trongate {
         redirect('member-login');
     }
 
-    // The member is authenticated &mdash; show the page
+    // The member is authenticated  -  show the page
     $data['view_module'] = 'members';
     $data['view_file'] = 'your_account';
     $this-&gt;templates-&gt;public($data);
-}</code></pre>
+}[/code]
 
   <p>
     Let us break that down:
   </p>
 
   <ol>
-    <li><code>$member_level_id = 2</code> &mdash; we are checking for level 2 (members).</li>
-    <li><code>$this-&gt;trongate_tokens-&gt;attempt_get_valid_token(2)</code> &mdash; this looks for a valid token for a member. If found, it returns the token. If not, it returns <code>false</code>.</li>
+    <li><code>$member_level_id = 2</code>  -  we are checking for level 2 (members).</li>
+    <li><code>$this-&gt;trongate_tokens-&gt;attempt_get_valid_token(2)</code>  -  this looks for a valid token for a member. If found, it returns the token. If not, it returns <code>false</code>.</li>
     <li>If the token is <code>false</code>, we redirect to the login page. The member never sees the protected content.</li>
     <li>If the token is valid, we show the page.</li>
   </ol>
@@ -109,13 +109,13 @@ class Members extends Trongate {
     There is another way to check if someone is logged in. The login module provides an <code>is_logged_in()</code> method:
   </p>
 
-  <pre><code>$this-&gt;module('login');
+  [code=php]$this-&gt;module('login');
 
 if ($this-&gt;login-&gt;is_logged_in(2) === true) {
     // Member is logged in!
 } else {
     // Member is not logged in.
-}</code></pre>
+}[/code]
 
   <p>
     Use whichever one you prefer. <code>attempt_get_valid_token()</code> gives you the token object (which contains the user's ID), while <code>is_logged_in()</code> simply returns <code>true</code> or an error message.

--- a/assets/trongate_way/0021Understanding_Trongates_Login_System/0070putting_it_all_together.html
+++ b/assets/trongate_way/0021Understanding_Trongates_Login_System/0070putting_it_all_together.html
@@ -8,11 +8,11 @@
 
   <h2>The Complete Members Controller</h2>
 
-  <pre><code>&lt;?php
+  [code=php]&lt;?php
 class Members extends Trongate {
 
     /**
-     * Welcome page &mdash; shown after successful login.
+     * Welcome page  -  shown after successful login.
      */
     public function welcome(): void {
         $data['view_module'] = 'members';
@@ -29,7 +29,7 @@ class Members extends Trongate {
     }
 
     /**
-     * Protected account page &mdash; only visible to logged-in members.
+     * Protected account page  -  only visible to logged-in members.
      */
     public function your_account(): void {
         $token = $this-&gt;trongate_tokens-&gt;attempt_get_valid_token(2);
@@ -102,13 +102,13 @@ class Members extends Trongate {
             redirect('member-login');
         }
 
-        // Validation failed &mdash; show the form again with errors
+        // Validation failed  -  show the form again with errors
         $data['view_module'] = 'members';
         $data['view_file'] = 'create_account';
         $this-&gt;templates-&gt;public($data);
     }
 
-}</code></pre>
+}[/code]
 
   <h2>What You Have Learned</h2>
 
@@ -139,7 +139,7 @@ class Members extends Trongate {
     <li><strong>Every user needs a trongate_users record.</strong> This is the master list. Their details go in the per-level table (like <code>members</code>).</li>
     <li><strong>Column names must match.</strong> The <code>fields</code> in your config must use the exact column names from your database table.</li>
     <li><strong>Use <code>attempt_get_valid_token()</code> to protect pages.</strong> Check for a valid token at the top of any method that should be member-only.</li>
-    <li><strong>Use <code>$this-&gt;login-&gt;hash_password()</code> when creating users.</strong> Never hash passwords manually &mdash; the login module uses the correct settings from your config.</li>
+    <li><strong>Use <code>$this-&gt;login-&gt;hash_password()</code> when creating users.</strong> Never hash passwords manually  -  the login module uses the correct settings from your config.</li>
   </ul>
 
   <h2>Where to Go Next</h2>
@@ -155,7 +155,7 @@ class Members extends Trongate {
   </ul>
 
   <p>
-    Congratulations &mdash; you have built a complete login system with Trongate v2!
+    Congratulations  -  you have built a complete login system with Trongate v2!
   </p>
 
 </div>

--- a/assets/trongate_way/0021Understanding_Trongates_Login_System/0080password_recovery.html
+++ b/assets/trongate_way/0021Understanding_Trongates_Login_System/0080password_recovery.html
@@ -7,15 +7,15 @@
   </p>
 
   <p>
-    When you created your administrator account (or any other user account on your Trongate site), your password was stored in a database table. For administrators, this is the <code>trongate_administrators</code> table. For other types of users &mdash; such as members &mdash; it would be whatever table you set up for them (for example, a table called <code>members</code>).
+    When you created your administrator account (or any other user account on your Trongate site), your password was stored in a database table. For administrators, this is the <code>trongate_administrators</code> table. For other types of users  -  such as members  -  it would be whatever table you set up for them (for example, a table called <code>members</code>).
   </p>
 
   <p>
-    In every case, the password lives in a column called <code>password</code> (or whatever you named it in your configuration). The data in that column is scrambled &mdash; it is turned into a long, unreadable string using a process called bcrypt hashing. This is a good thing. It means that even if someone were to see your database, they would not be able to read your password.
+    In every case, the password lives in a column called <code>password</code> (or whatever you named it in your configuration). The data in that column is scrambled  -  it is turned into a long, unreadable string using a process called bcrypt hashing. This is a good thing. It means that even if someone were to see your database, they would not be able to read your password.
   </p>
 
   <p>
-    But here is the good news: even though your password is scrambled, you can still create a new one. The rest of this page will show you how, step by step. The instructions work whether your website is running in development mode or in live/production mode, and they work for any user level &mdash; administrators, members, or any other type of user you have set up.
+    But here is the good news: even though your password is scrambled, you can still create a new one. The rest of this page will show you how, step by step. The instructions work whether your website is running in development mode or in live/production mode, and they work for any user level  -  administrators, members, or any other type of user you have set up.
   </p>
 
   <div class="alert alert-info">
@@ -58,7 +58,7 @@
   </p>
 
   <p>
-    This feature allows a user to request a password reset email. They enter their email address, receive a link, and choose a new password &mdash; all without needing anyone else's help.
+    This feature allows a user to request a password reset email. They enter their email address, receive a link, and choose a new password  -  all without needing anyone else's help.
   </p>
 
   <h3>Step 1: Enable the Forgot Password Feature</h3>
@@ -67,11 +67,11 @@
     By default, the forgot password feature is disabled for administrators. Open your <code>config/login.php</code> file and find the administrator user level (level 1). Change this:
   </p>
 
-  <pre><code>'enable_forgot_password' =&gt; false</code></pre>
+  [code]'enable_forgot_password' =&gt; false[/code]
 
   <p>to this:</p>
 
-  <pre><code>'enable_forgot_password' =&gt; true</code></pre>
+  [code]'enable_forgot_password' =&gt; true[/code]
 
   <p>Save the file.</p>
 
@@ -85,7 +85,7 @@
     Create a file at <code>config/trongate_email.php</code> with your SMTP credentials:
   </p>
 
-  <pre><code>&lt;?php
+  [code=php]&lt;?php
 $config['trongate_email'] = [
     'smtp_host'       =&gt; 'mail.yourdomain.com',
     'smtp_port'       =&gt; 465,
@@ -93,7 +93,7 @@ $config['trongate_email'] = [
     'smtp_pass'       =&gt; 'your-password-here',
     'smtp_secure'     =&gt; 'ssl',
     'smtp_from_name'  =&gt; 'Your Website Name'
-];</code></pre>
+];[/code]
 
   <p>
     Replace the values above with your actual SMTP details. Your web host or email provider can give you these settings.
@@ -105,11 +105,11 @@ $config['trongate_email'] = [
     Once the configuration is ready, the forgot password link will appear on your login form automatically. A user can also visit the forgot password page directly at:
   </p>
 
-  <pre><code>http://yoursite.com/login/forgot_password/{secret_word}</code></pre>
+  [code]http://yoursite.com/login/forgot_password/{secret_word}[/code]
 
   <p>For administrators, this would be:</p>
 
-  <pre><code>http://yoursite.com/login/forgot_password/tg-admin</code></pre>
+  [code]http://yoursite.com/login/forgot_password/tg-admin[/code]
 
   <p>Here is how the full flow works:</p>
 


### PR DESCRIPTION
Three fixes applied across all 8 pages of the Understanding Trongate's Login System chapter:

1. **Code blocks**: Converted all pre/code tags to [code] / [code=language] format (PHP, SQL, HTML, and plain text blocks tagged appropriately)
2. **Em-dashes**: Replaced all &mdash; with " - " (space-hyphen-space)
3. **Quick Start links**: Updated placeholder links to point to the Password Recovery page