### PR TITLE
Resolve merge conflicts in password recovery page

### DIFF
--- a/assets/trongate_way/0021Understanding_Trongates_Login_System/0080password_recovery.html
+++ b/assets/trongate_way/0021Understanding_Trongates_Login_System/0080password_recovery.html
@@ -7,17 +7,6 @@
   </p>
 
   <p>
-<<<<<<< HEAD
-    When you created your administrator account (or any other user account on your Trongate site), your password was stored in a database table. For administrators, this is the <code>trongate_administrators</code> table. For other types of users - such as members - it would be whatever table you set up for them (for example, a table called <code>members</code>).
-  </p>
-
-  <p>
-    In every case, the password lives in a column called <code>password</code> (or whatever you named it in your configuration). The data in that column is scrambled - it is turned into a long, unreadable string using a process called bcrypt hashing. This is a good thing. It means that even if someone were to see your database, they would not be able to read your password.
-  </p>
-
-  <p>
-    But here is the good news: even though your password is scrambled, you can still create a new one. The rest of this page will show you how, step by step. The instructions work whether your website is running in development mode or in live/production mode, and they work for any user level - administrators, members, or any other type of user you have set up.
-=======
     When you created your administrator account (or any other user account on your Trongate site), your password was stored in a database table. For administrators, this is the <code>trongate_administrators</code> table. For other types of users  -  such as members  -  it would be whatever table you set up for them (for example, a table called <code>members</code>).
   </p>
 
@@ -27,7 +16,6 @@
 
   <p>
     But here is the good news: even though your password is scrambled, you can still create a new one. The rest of this page will show you how, step by step. The instructions work whether your website is running in development mode or in live/production mode, and they work for any user level  -  administrators, members, or any other type of user you have set up.
->>>>>>> 7cc53b4b503cf3f5c7cd6f2019a6ec0307b2229b
   </p>
 
   <div class="alert alert-info">
@@ -70,11 +58,7 @@
   </p>
 
   <p>
-<<<<<<< HEAD
-    This feature allows a user to request a password reset email. They enter their email address, receive a link, and choose a new password - all without needing anyone else's help.
-=======
     This feature allows a user to request a password reset email. They enter their email address, receive a link, and choose a new password  -  all without needing anyone else's help.
->>>>>>> 7cc53b4b503cf3f5c7cd6f2019a6ec0307b2229b
   </p>
 
   <h3>Step 1: Enable the Forgot Password Feature</h3>
@@ -83,19 +67,11 @@
     By default, the forgot password feature is disabled for administrators. Open your <code>config/login.php</code> file and find the administrator user level (level 1). Change this:
   </p>
 
-<<<<<<< HEAD
-  [code=php]'enable_forgot_password' =&gt; false[/code]
-
-  <p>to this:</p>
-
-  [code=php]'enable_forgot_password' =&gt; true[/code]
-=======
   [code]'enable_forgot_password' =&gt; false[/code]
 
   <p>to this:</p>
 
   [code]'enable_forgot_password' =&gt; true[/code]
->>>>>>> 7cc53b4b503cf3f5c7cd6f2019a6ec0307b2229b
 
   <p>Save the file.</p>
 


### PR DESCRIPTION
Fixed 3 merge conflicts in 0080password_recovery.html that left conflict markers (<<<<<<<, =======, >>>>>>>) in the file. Resolved by:

1. Keeping double-space hyphens (David's formatting preference)
2. Using plain [code] tags for short config snippets
3. Keeping [code=php] for full PHP code blocks

No content changes - just conflict resolution.