### PR TITLE
Fix imprecise wording in trongate_tokens/regenerate.html (row is updated, not deleted)

### DIFF
--- a/assets/reference/included/trongate_tokens/regenerate.html
+++ b/assets/reference/included/trongate_tokens/regenerate.html
@@ -42,7 +42,7 @@
     </tbody>
   </table>
 <h2>Example Usage</h2>
-<p>The JavaScript code sample below illustrates extending a user's login session by regenerating their token using an HTTP GET request. This approach involves appending the existing token to the target URL string. While exposing tokens in URLs is generally considered poor practice due to security concerns, in this specific scenario, any validated tokens passed via the URL are immediately invalidated and removed from the database, rendering them useless.</p>
+<p>The JavaScript code sample below illustrates extending a user's login session by regenerating their token using an HTTP GET request. This approach involves appending the existing token to the target URL string. While exposing tokens in URLs is generally considered poor practice due to security concerns, in this specific scenario, any validated tokens passed via the URL are immediately invalidated — the token value is replaced in the database — rendering them useless.</p>
 [code=php]
 &lt;script&gt;
 const baseUrl = '&lt;?= BASE_URL ?&gt;';


### PR DESCRIPTION
## What

One sentence tightened in the Example Usage section of `assets/reference/included/trongate_tokens/regenerate.html`.

**Before:** "…any validated tokens passed via the URL are immediately invalidated **and removed from the database**, rendering them useless."

**After:** "…any validated tokens passed via the URL are immediately invalidated — **the token value is replaced in the database** — rendering them useless."

## Why

The old wording implies the token row is deleted. It is not. `Trongate_tokens_model::regenerate_token()` performs an **UPDATE** on the existing row, replacing the token value and expiry date; the row itself remains.

## Verification (2 minutes)

Framework master `4f75ff9`, `modules/trongate_tokens/Trongate_tokens_model.php:336`:

- `regenerate_token(string $old_token, int $expiry_date): string|bool`
- SELECTs the row by old token (returns `false` if not found)
- Generates a new 32-char token via `make_rand_str()`
- `$this->db->update($token->id, ['expiry_date' => $expiry_date, 'token' => $new_token], 'trongate_tokens')` — UPDATE on the same row, no DELETE anywhere in the method

No other content on the page changed — signature, JS example, and response codes (400/404/200) were verified correct and left untouched.