### PR TITLE
[Mike] Fix non-existent Db::insert_id() in login-system docs

### DIFF
--- a/assets/trongate_way/0020Understanding_Trongates_Login_System/0070putting_it_all_together.html
+++ b/assets/trongate_way/0020Understanding_Trongates_Login_System/0070putting_it_all_together.html
@@ -77,14 +77,11 @@ class Members extends Trongate {
 
         if ($result === true) {
             // Create the trongate_users record
-            $sql = 'INSERT INTO trongate_users (user_level_id, code)
-                    VALUES (:user_level_id, :code)';
-            $params = [
+            $trongate_user_data = [
                 'user_level_id' =&gt; 2,
                 'code' =&gt; make_rand_str(32)
             ];
-            $this-&gt;db-&gt;query_bind($sql, $params);
-            $trongate_user_id = $this-&gt;db-&gt;insert_id();
+            $trongate_user_id = $this-&gt;db-&gt;insert($trongate_user_data, 'trongate_users');
 
             // Create the members record
             $data['username'] = post('username', true);

--- a/assets/trongate_way/0021How_To_Build_A_Login_System/0060_login_logout_and_password_resets.html
+++ b/assets/trongate_way/0021How_To_Build_A_Login_System/0060_login_logout_and_password_resets.html
@@ -35,13 +35,11 @@ public function create_account(): void {
     if ($result === true) {
 
         // Create the trongate_users record
-        $sql = 'INSERT INTO trongate_users (user_level_id, code) VALUES (:user_level_id, :code)';
-        $params = [
+        $trongate_user_data = [
             'user_level_id' => 2,
             'code' => make_rand_str(32)
         ];
-        $this->db->query_bind($sql, $params);
-        $trongate_user_id = $this->db->insert_id();
+        $trongate_user_id = $this->db->insert($trongate_user_data, 'trongate_users');
 
         // Create the members record
         $data['username'] = post('username', true);

--- a/assets/trongate_way/0021How_To_Build_A_Login_System/0070complete_example_and_summary.html
+++ b/assets/trongate_way/0021How_To_Build_A_Login_System/0070complete_example_and_summary.html
@@ -63,13 +63,11 @@ class Members extends Trongate {
 
         if ($result === true) {
             // Create the trongate_users record
-            $sql = 'INSERT INTO trongate_users (user_level_id, code) VALUES (:user_level_id, :code)';
-            $params = [
+            $trongate_user_data = [
                 'user_level_id' => 2,
                 'code' => make_rand_str(32)
             ];
-            $this->db->query_bind($sql, $params);
-            $trongate_user_id = $this->db->insert_id();
+            $trongate_user_id = $this->db->insert($trongate_user_data, 'trongate_users');
 
             // Create the members record
             $data['username'] = post('username', true);


### PR DESCRIPTION
Replaces three occurrences of `$this->db->insert_id()` — a method that **does not exist in Trongate v2** (`Db extends Trongate`, no `__call` fallback) — with the correct v2 idiom, which also returns the last insert id:

```php
$trongate_user_id = $this->db->insert($trongate_user_data, 'trongate_users');
```

`Db::insert(array $data, string $table): int` returns `(int) $this->dbh->lastInsertId()` (verified in framework source, `modules/db/Db.php`).

Occurrences fixed (repo-relative paths, as flagged by Grady in the knowledge-exchange repo):

1. `assets/trongate_way/0021How_To_Build_A_Login_System/0070complete_example_and_summary.html:72`
2. `assets/trongate_way/0021How_To_Build_A_Login_System/0060_login_logout_and_password_resets.html:44`
3. `assets/trongate_way/0020Understanding_Trongates_Login_System/0070putting_it_all_together.html:87`

Each replaced block used raw SQL (`query_bind`) + `insert_id()`; now it builds a `$trongate_user_data` array and inserts via `Db::insert()`, matching the framework's own canonical pattern (`modules/trongate_administrators/Trongate_administrators_model.php`).

— Mike