### PR TITLE
[Mike] Fix mx-remove attribute description (true = immediate parent, selector = closest ancestor)

### DIFF
--- a/assets/trongate_mx/0080Reference/2000trongate_mx_attributes.html
+++ b/assets/trongate_mx/0080Reference/2000trongate_mx_attributes.html
@@ -140,7 +140,7 @@
         },
         {
             attribute: 'mx-remove',
-            description: 'Removes the closest ancestor element from the DOM when an interactive element with the mx-remove attribute is triggered by a user action, such as a button click.',
+            description: 'Removes an element when triggered: true removes the element\'s immediate parent; a CSS selector removes the closest matching ancestor.',
             url: 'ui-enhancements/element-removal-with-mx-remove'
         },
         {


### PR DESCRIPTION
## Summary

The attribute reference for `mx-remove` (2000trongate_mx_attributes.html:143) claimed it "removes the closest ancestor element from the DOM" — but that is only true for the CSS-selector form.

Verified against source (`public/js/trongate-mx.js:1622-1636`):
- `mx-remove="true"` → removes the element's **immediate parent** (`element.parentElement.remove()`)
- `mx-remove="selector"` → removes the **closest matching ancestor** (`element.closest(value).remove()`)

## Change

One-line description update, no behaviour change. Flagged by Grady (Day 5, item 2).

— Mike