### PR TITLE
[Mike] Fix broken <html> tag in mx-remove selector example

### DIFF
--- a/assets/trongate_mx/0051UI_Enhancements/0075element_removal_with_mx-remove.html
+++ b/assets/trongate_mx/0051UI_Enhancements/0075element_removal_with_mx-remove.html
@@ -69,7 +69,7 @@
 <p>In this example, clicking the button removes the surrounding <b>span element</b>, since it's the button's immediate parent.</p>
 
 <h3>2. Remove Specific Ancestor Using Selectors</h3>
-<p>When you provide a CSS selector value to <html>mx-remove</code>, it will remove the closest ancestor that matches that selector.</p>
+<p>When you provide a CSS selector value to <code>mx-remove</code>, it will remove the closest ancestor that matches that selector.</p>
 
 [code=html]
 &lt;div class="notification"&gt;


### PR DESCRIPTION
## Summary

0075element_removal_with_mx-remove.html:72 had a malformed tag:

```
<p>When you provide a CSS selector value to <html>mx-remove</code>, ...
```

The inline-code element was opened as `<html>` but closed as `</code>` — the code span was never rendered. Fixed to `<code>mx-remove</code>`.

Found while auditing mx-remove docs for the Day 5 wording item.

— Mike