### PR TITLE
fix: video container internals match shipped CSS

### DIFF
--- a/assets/trongate_css/0070media_and_animations/0010video_container_classes.html
+++ b/assets/trongate_css/0070media_and_animations/0010video_container_classes.html
@@ -41,32 +41,23 @@
 [/code]  
 
 <h2>How It Works</h2>  
-<p>The video container classes use CSS custom properties to maintain the correct aspect ratio. The key is the <code>padding-bottom</code> value, which is calculated based on the aspect ratio:</p>  
+<p>The video container classes use the modern CSS <code>aspect-ratio</code> property to maintain the correct aspect ratio:</p>  
 
 [code=css]  
 .video-container {  
-    --aspect-w: 16;  
-    --aspect-h: 9;  
-    position: relative;  
     width: 100%;  
-    height: 0;  
-    padding-bottom: calc(100% * (var(--aspect-h) / var(--aspect-w)));  
+    aspect-ratio: 16 / 9;  
 }  
 
 .video-container.aspect-4-3 {  
-    --aspect-w: 4;  
-    --aspect-h: 3;  
+    aspect-ratio: 4 / 3;  
 }  
 
 .video-container.aspect-1-1 {  
-    --aspect-w: 1;  
-    --aspect-h: 1;  
+    aspect-ratio: 1 / 1;  
 }  
 
 .video {  
-    position: absolute;  
-    top: 0;  
-    left: 0;  
     width: 100%;  
     height: 100%;  
     border: 0;  


### PR DESCRIPTION
The chapter documented a `padding-bottom` calc technique with `--aspect-w`/`--aspect-h` custom properties. The shipped framework (`public/css/trongate.css:361-370`) uses the native `aspect-ratio` property:

```css
.video-container { width: 100%; aspect-ratio: 16 / 9; }
.video-container.aspect-4-3 { aspect-ratio: 4 / 3; }
.video-container.aspect-1-1 { aspect-ratio: 1 / 1; }
.video { width: 100%; height: 100%; border: 0; }
```

The public classes are unchanged; only the documented internals are updated to match the shipped file. One issue per PR, signed [Grady], David sole reviewer.