### PR TITLE
fix: replace phantom .secondary-dark demo class with .inverse

### DIFF
--- a/assets/trongate_css/0020css_fundamentals/0060responsive_design.html
+++ b/assets/trongate_css/0020css_fundamentals/0060responsive_design.html
@@ -59,7 +59,7 @@ img {
 <div class="trongate-css-demo">
     <div>
         <p class="text-center">
-            <button class="secondary-dark mt-0" onclick="openModal('example-modal')">Click Me!</button>
+            <button class="inverse mt-0" onclick="openModal('example-modal')">Click Me!</button>
         </p>
     </div>
 </div>

--- a/assets/trongate_css/0040cards_and_modals/0020working_with_modals.html
+++ b/assets/trongate_css/0040cards_and_modals/0020working_with_modals.html
@@ -5,7 +5,7 @@
 <div class="trongate-css-demo">
     <div>
         <p class="text-center">
-            <button class="secondary-dark mt-0" onclick="openModal('example-modal')">Click Me!</button>
+            <button class="inverse mt-0" onclick="openModal('example-modal')">Click Me!</button>
         </p>
     </div>
 </div>

--- a/assets/trongate_css/0067utility_classes/0050cloaking_elements.html
+++ b/assets/trongate_css/0067utility_classes/0050cloaking_elements.html
@@ -138,7 +138,7 @@ function toggleShipping() {
 <div class="trongate-css-demo">
     <div>
         <p class="text-center">
-            <button class="secondary-dark mt-0" onclick="openModal('example-modal')">Click Me!</button>
+            <button class="inverse mt-0" onclick="openModal('example-modal')">Click Me!</button>
         </p>
     </div>
 </div>


### PR DESCRIPTION
Three book demos use `class="secondary-dark"` on buttons (responsive_design.html:62, working_with_modals.html:8, cloaking_elements.html:141). No such class exists in the framework — only the `--secondary-dark` token (`trongate.css:22`) — so the demos silently render default-styled buttons.

Replaced with the real `.inverse` class (`trongate.css:152-153`), the closest shipped dark variant. The valid `var(--secondary-dark)` usages in table_variations.html and working_with_cards.html are untouched.

One issue per PR, signed [Grady], David sole reviewer.