### PR TITLE
[Mike] Document scoped validation errors (validation_errors FORM- prefix, form_name attribute, render-and-clear lifecycle)

### DIFF
--- a/assets/php_framework/0125Form_Handling/0010creating_forms.html
+++ b/assets/php_framework/0125Form_Handling/0010creating_forms.html
@@ -83,6 +83,36 @@ echo form_open('auth/login', $attributes);
 &amp;lt;form action="https://yoursite.com/auth/login" method="post" id="login-form" class="highlight-errors"&amp;gt;
 [/code]
 
+<h2>Naming a Form (Scoped Validation Errors)</h2>
+
+<p>On pages with more than one form, pass a <code>form_name</code> attribute to scope validation errors to a particular form. The name is <strong>never rendered as an HTML attribute</strong> — instead, an escaped hidden input is injected right after the opening tag:</p>
+
+[code=vf]
+$attributes = [
+    'form_name' =&gt; 'login'
+];
+
+echo form_open('auth/login', $attributes);
+[/code]
+
+<p>Output:</p>
+
+[code=html]
+&amp;lt;form action="https://yoursite.com/auth/login" method="post"&amp;gt;
+&amp;lt;input type="hidden" name="form_name" value="login"&amp;gt;
+[/code]
+
+<p>Then render only that form's errors with the scoped spelling:</p>
+
+[code=vf]
+&lt;?= validation_errors('FORM-login') ?&gt;
+[/code]
+
+<div class="alert alert-info">
+    <p><strong>Constraints:</strong> <code>form_name</code> is opt-in, strings only, and capped at 64 characters (mirroring the guard in <code>Validation::run()</code>). A form that declares no <code>form_name</code> renders errors via the global spelling only — a scoped call on an unnamed form renders nothing, silently.</p>
+    <p><strong>Reserved name:</strong> <code>form_name</code> joins <code>csrf_token</code> as a field name reserved by the form helpers. Don't use either as an ordinary field name.</p>
+</div>
+
 <h2>Changing the HTTP Method</h2>
 
 <p>By default, forms use <code>POST</code>. To use <code>GET</code>:</p>

--- a/assets/php_framework/0127Form_validation/0045displaying_validation_errors.html
+++ b/assets/php_framework/0127Form_validation/0045displaying_validation_errors.html
@@ -2,9 +2,9 @@
 
 <h1>Displaying Validation Errors</h1>
 
-<p>When validation fails, Trongate stores errors in <code>$_SESSION['form_submission_errors']</code> and provides three simple ways to display them.</p>
+<p>When validation fails, Trongate stores errors in <code>$_SESSION['form_submission_errors']</code> and provides four ways to display them.</p>
 
-<h2>The Three Display Methods</h2>
+<h2>The Four Display Methods</h2>
 
 <table class="table sm">
   <thead>
@@ -19,6 +19,11 @@
       <td><strong>General Errors</strong></td>
       <td><code>validation_errors()</code></td>
       <td>Simple forms, login pages, admin panels</td>
+    </tr>
+    <tr>
+      <td><strong>Scoped Errors</strong></td>
+      <td><code>validation_errors('FORM-login')</code></td>
+      <td>Pages with more than one form</td>
     </tr>
     <tr>
       <td><strong>Inline Errors</strong></td>
@@ -75,7 +80,42 @@ define('ERROR_CLOSE', '&lt;/div&gt;');
   </li>
 </ul>
 
-<h2>Method 2: Inline Errors (Field-Specific)</h2>
+<h2>Method 2: Scoped Errors (Form-Specific)</h2>
+
+<p>On pages with more than one form, give each form a <code>form_name</code> and render only that form's errors with the <code>FORM-</code> prefix. This prevents one form's errors from appearing under a different form.</p>
+
+[code=vf]
+&lt;?php
+echo form_open($login_location, ['form_name' =&gt; 'login']);
+echo form_label('Email');
+echo form_input('email', $email);
+echo form_label('Password');
+echo form_password('password');
+echo form_submit('submit', 'Log In');
+echo validation_errors('FORM-login'); // Login form's errors only
+echo form_close();
+
+// Second form on the same page...
+echo form_open($contact_location, ['form_name' =&gt; 'contact']);
+// ... contact fields ...
+echo validation_errors('FORM-contact'); // Contact form's errors only
+echo form_close();
+?&gt;
+[/code]
+
+<p>Scoped rendering uses the default error wrappers. For custom wrappers plus scoping, use the position-3 spelling:</p>
+
+[code=vf]
+&lt;?= validation_errors('&lt;/p&gt;', '&lt;p&gt;', 'login') ?&gt;
+[/code]
+
+<div class="alert alert-warning">
+  <p><strong>Abstain without clearing:</strong> when the requested name does not match the recorded name (wrong name, or no name recorded), the scoped call renders nothing and does <strong>not</strong> clear the error bucket — the correct form's block still renders.</p>
+  <p><strong>Footgun:</strong> a scoped call on a form that declared no <code>form_name</code> renders nothing, silently. Unnamed forms use the global spelling (<code>validation_errors()</code>).</p>
+  <p><strong>POST-only scoping:</strong> the form name is read from the submitted POST data. GET forms never record a name, so scoped calls on GET forms always abstain.</p>
+</div>
+
+<h2>Method 3: Inline Errors (Field-Specific)</h2>
 
 <p>Pass a field name to display errors next to the relevant input. This provides a more precise and user-friendly experience.</p>
 
@@ -98,7 +138,7 @@ echo form_close();
 
 <p>This method is ideal for longer or more complex forms where users benefit from seeing exactly where problems occur.</p>
 
-<h2>Method 3: JSON Errors (APIs and AJAX)</h2>
+<h2>Method 4: JSON Errors (APIs and AJAX)</h2>
 
 <p>Pass an HTTP status code (400–499) to return validation errors as JSON and immediately terminate execution.</p>
 
@@ -153,6 +193,7 @@ echo form_close();
 <ul>
   <li><strong>Simple forms:</strong> Use general errors</li>
   <li><strong>Complex forms:</strong> Use inline errors</li>
+  <li><strong>Multi-form pages:</strong> Use scoped errors</li>
   <li><strong>APIs:</strong> Use JSON responses</li>
 </ul>
 
@@ -169,8 +210,10 @@ echo form_close();
 
   <ul>
     <li><code>validation_errors()</code> displays all errors and clears them</li>
+    <li><code>validation_errors('FORM-login')</code> displays a named form's errors and clears them; on a name mismatch it renders nothing and leaves the bucket intact</li>
     <li><code>validation_errors('field')</code> displays errors for one field and clears only that field’s errors</li>
     <li><code>validation_errors(422)</code> returns JSON, clears all errors, and terminates execution</li>
-    <li><code>$this-&gt;validation-&gt;run()</code> clears previous errors before running validation again</li>
+    <li><code>$this-&gt;validation-&gt;run()</code> clears the bucket and recorded form name on a successful submission (clear-on-pass)</li>
+    <li><code>form_close()</code> does <strong>not</strong> clear validation errors — the summary call is safe <strong>anywhere</strong>: before the form, inside the block, or after <code>form_close()</code></li>
   </ul>
 </div>

--- a/assets/php_framework/0127Form_validation/0068csrf_protection.html
+++ b/assets/php_framework/0127Form_validation/0068csrf_protection.html
@@ -161,6 +161,10 @@ public function submit(): void {
 
 <p>However, this is exactly why you should use <span class="feature-ref">form_open()</span> and <span class="feature-ref">form_close()</span> - they handle the token automatically and consistently.</p>
 
+<div class="alert alert-info">
+    <p><strong>Reserved field names:</strong> <code>csrf_token</code> is injected by <span class="feature-ref">form_close()</span> and <code>form_name</code> is injected by <span class="feature-ref">form_open()</span> (when a <code>form_name</code> attribute is set, for scoped validation errors). Neither should be used as an ordinary field name in your own forms.</p>
+</div>
+
 <div class="alert alert-success">
     <p><strong>Best Practice:</strong> Always use the Trongate form helpers. They ensure CSRF tokens are present and correctly formatted with zero effort on your part.</p>
 </div>

--- a/assets/reference/helpers/form_helpers/form_close.html
+++ b/assets/reference/helpers/form_helpers/form_close.html
@@ -125,7 +125,6 @@ public function submit(): void {
 <ol>
     <li>Injects errors as JavaScript (<code>window.trongateValidationErrors</code>)</li>
     <li>Injects highlighting script that adds the <code>form-field-validation-error</code> class to fields with errors</li>
-    <li>Clears validation errors from the session</li>
 </ol>
 
 <p>Example form with error highlighting:</p>
@@ -150,8 +149,9 @@ echo form_close(); // Adds CSRF token + injects error highlighting if errors exi
     <li>Always use <code>form_close()</code> to close forms opened with <code>form_open()</code></li>
     <li>GET forms (like search forms) don't need CSRF protection - but you should still use <code>form_close()</code> for consistency</li>
     <li>The CSRF token is validated automatically by <code>$this-&gt;validation-&gt;run()</code></li>
-    <li>When validation errors exist in the session, <code>form_close()</code> injects error highlighting JavaScript and clears the errors</li>
+    <li>When validation errors exist in the session, <code>form_close()</code> injects error highlighting JavaScript</li>
     <li>Error highlighting only works when the form has the <code>highlight-errors</code> class</li>
+    <li><code>form_close()</code> does <strong>not</strong> clear validation errors from the session — the error bucket's lifecycle is render-and-clear, owned by the rendering calls (<code>validation_errors()</code> and <code>display_errors()</code>). A summary call may now be placed after <code>form_close()</code> and still render.</li>
 </ul>
 
 <h2>Best Practice Pattern</h2>

--- a/assets/reference/helpers/form_helpers/form_open.html
+++ b/assets/reference/helpers/form_helpers/form_open.html
@@ -77,6 +77,24 @@ echo form_open('#', $attributes);
 // &amp;lt;form mx-post="comments/create" mx-target="#comment-list" mx-swap="beforeend" action="#" method="post"&amp;gt;
 [/code]
 
+    <h2>Example #5: Named Form (Scoped Validation Errors)</h2>
+    <p>Pass a <code>form_name</code> attribute to give the form a name. The name is used to scope validation errors to this form — see <span class="feature-ref">validation_errors()</span> Mode 4. It is <strong>never rendered as an HTML attribute</strong> on the form tag; instead, an escaped hidden input is injected right after the opening tag:</p>
+[code=php]
+$attributes = [
+    'form_name' =&gt; 'login'
+];
+echo form_open('auth/login', $attributes);
+
+// Output:
+// &amp;lt;form action="https://example.com/auth/login" method="post"&amp;gt;
+// &amp;lt;input type="hidden" name="form_name" value="login"&amp;gt;
+[/code]
+
+    <div class="alert alert-info">
+        <p><strong>Constraints:</strong> <code>form_name</code> is opt-in, strings only, and capped at 64 characters — mirroring the key-hygiene guard in <code>Validation::run()</code>. A name <code>run()</code> would never record is never injected, so declared and recorded can never diverge.</p>
+        <p><strong>Reserved names:</strong> <code>form_name</code> joins <code>csrf_token</code> as a field name reserved by the form helpers. Do not use either as an ordinary field name in your own forms.</p>
+    </div>
+
 <div class="alert alert-info">
     <p><strong>Regarding Trongate MX:</strong> When using MX attributes like <code>mx-post</code>, the form submits asynchronously without page reloads. The <code>mx-post</code> attribute takes precedence over the <code>action</code> attribute.</p>
 
@@ -108,6 +126,7 @@ echo form_open('https://api.example.com/submit');
         <li>Relative paths are automatically converted to full URLs using the <code>BASE_URL</code> constant.</li>
         <li>All attributes are automatically HTML-escaped for security.</li>
         <li>The <code>method</code> attribute is handled specially - it's extracted from the attributes array and placed in the proper position.</li>
+        <li>The <code>form_name</code> attribute is also handled specially - it's extracted from the attributes array, never rendered as an HTML attribute, and used to inject a hidden <code>form_name</code> input for scoped validation errors.</li>
     </ul> 
 </div>
 

--- a/assets/reference/helpers/form_helpers/validation_errors.html
+++ b/assets/reference/helpers/form_helpers/validation_errors.html
@@ -1,14 +1,14 @@
 <div class="container">
     <h1>validation_errors()</h1>
-    <p class="signature">function validation_errors(string|int|null $first_arg = null, ?string $closing_html = null): ?string</p>
+    <p class="signature">function validation_errors(string|int|null $first_arg = null, ?string $closing_html = null, ?string $scope = null): ?string</p>
     
     <div class="alert alert-info">
-        <p><strong>Quick Start:</strong> Use <code>validation_errors()</code> for general form errors, <code>validation_errors('fieldname')</code> for inline errors, or <code>validation_errors(422)</code> for JSON API responses.</p>
+        <p><strong>Quick Start:</strong> Use <code>validation_errors()</code> for general form errors, <code>validation_errors('FORM-login')</code> for errors belonging to one named form, <code>validation_errors('fieldname')</code> for inline errors, or <code>validation_errors(422)</code> for JSON API responses.</p>
     </div>
 
     <h2>Description</h2>
     <div class="description">
-        <p>Displays validation error messages stored in the session. This flexible function supports three output modes: general error display, inline field-specific errors, and JSON error responses for APIs.</p>
+        <p>Displays validation error messages stored in the session. This flexible function supports four output modes: general error display, scoped error display for a named form, inline field-specific errors, and JSON error responses for APIs.</p>
     </div>
 
     <h2>Parameters</h2>
@@ -27,6 +27,7 @@
                 <td>
                     (optional) This overloaded argument determines the function's mode:
                     <ul>
+                        <li>If <code>string</code> starting with <code>FORM-</code>: The name of a form for scoped error reporting (e.g. <code>validation_errors('FORM-login')</code>). (Mode 4)</li>
                         <li>If <code>string</code> (no <code>$closing_html</code>): The name of a specific field for inline error reporting. (Mode 2)</li>
                         <li>If <code>int</code> (400-499): An HTTP status code to trigger a JSON error response. (Mode 3)</li>
                         <li>If <code>string</code> (with <code>$closing_html</code>): The opening HTML tag for custom error wrappers. (Mode 1 - Custom)</li>
@@ -37,7 +38,12 @@
             <tr>
                 <td><code>$closing_html</code></td>
                 <td>?string</td>
-                <td>(optional) The closing HTML tag when <code>$first_arg</code> is used as an opening HTML tag. Defaults to <code>null</code>.</td>
+                <td>(optional) The closing HTML tag when <code>$first_arg</code> is used as an opening HTML tag. Defaults to <code>null</code>. <strong>Unused in the <code>FORM-</code> prefix spelling</strong> — see Mode 4.</td>
+            </tr>
+            <tr>
+                <td><code>$scope</code></td>
+                <td>?string</td>
+                <td>(optional) A form name for scoped error rendering with custom wrappers. Only used in <em>standard</em> mode: <code>validation_errors('&lt;/p&gt;', '&lt;p&gt;', 'login')</code>. Defaults to <code>null</code>.</td>
             </tr>
         </tbody>
     </table>
@@ -59,7 +65,7 @@
     </table>
 
     <div class="alert alert-info">
-        <p><strong>Session Management:</strong> Errors are automatically cleared from the session after display. Each error set displays only once per request.</p>
+        <p><strong>Session Management:</strong> Errors are automatically cleared from the session after display. Each error set displays only once per request. A scoped call that <em>abstains</em> (name mismatch) does <strong>not</strong> clear the bucket — the correct form's block must still be able to render it.</p>
     </div>
 
     <h2>Mode 1: General Error Display (All Errors)</h2>
@@ -142,6 +148,44 @@ public function api_create(): void {
 ]
 [/code]
 
+    <h2>Mode 4: Scoped Errors (Form-Specific)</h2>
+    <p>Display errors belonging to one named form only. This is useful on pages with more than one form, where a global summary would mix errors from different forms.</p>
+
+    <p>Give the form a name with the <code>form_name</code> attribute of <span class="feature-ref">form_open()</span>, then render its errors with the <code>FORM-</code> prefix:</p>
+
+[code=vf]
+&lt;?php
+echo form_open('auth/login', ['form_name' =&gt; 'login']);
+// ... login fields ...
+echo validation_errors('FORM-login'); // login form's errors only
+?&gt;
+[/code]
+
+    <p>Scoped rendering uses the default error wrappers. Custom wrappers require the position-3 spelling:</p>
+
+[code=vf]
+&lt;?php
+// Scoped with custom wrappers:
+echo validation_errors('&lt;/p&gt;', '&lt;p&gt;', 'login');
+?&gt;
+[/code]
+
+    <div class="alert alert-warning">
+        <p><strong>Position 2 is unused in the prefix spelling:</strong> <code>validation_errors('FORM-login', '&lt;/p&gt;')</code> silently drops the wrapper — the prefix spelling always uses default wrappers. For custom wrappers plus scoping, use the position-3 <code>$scope</code> spelling above.</p>
+    </div>
+
+    <p><strong>Abstain semantics:</strong> when the requested name does not match the recorded name (wrong name, or no name recorded at all), the call returns <code>null</code> <em>without clearing</em> the error bucket — the correct form's block still renders.</p>
+
+    <p><strong>Constraints:</strong> form names are strings only, trimmed, and at most 64 characters. Longer or non-string names are never recorded by <code>run()</code> (and never injected by <code>form_open()</code>).</p>
+
+    <div class="alert alert-danger">
+        <p><strong>Footgun:</strong> a scoped call on a form that declared no <code>form_name</code> renders nothing, silently. If a page's form does not declare <code>form_name</code>, use the no-argument global spelling.</p>
+    </div>
+
+    <div class="alert alert-info">
+        <p><strong>Reservation:</strong> a field literally named <code>FORM-*</code> (uppercase prefix) is no longer reachable via inline <code>validation_errors('FORM-*')</code> — the prefix is reserved for scoped rendering. Lowercase <code>form-*</code> fields are unaffected.</p>
+    </div>
+
     <h2>Global Error Styling</h2>
     <p>Define default error wrappers in your configuration to avoid passing them as arguments every time:</p>
 
@@ -199,6 +243,18 @@ echo form_open('users/register', ['class' => 'highlight-errors']);
                 <td><code>validation_errors(422)</code></td>
                 <td>Mode 3</td>
                 <td>JSON with 422 status code and script exit</td>
+            </tr>
+            <tr>
+                <td>One form's errors (multi-form page)</td>
+                <td><code>validation_errors('FORM-login')</code></td>
+                <td>Mode 4</td>
+                <td>Only the named form's errors, default wrappers</td>
+            </tr>
+            <tr>
+                <td>One form's errors, custom wrappers</td>
+                <td><code>validation_errors('&lt;/p&gt;', '&lt;p&gt;', 'login')</code></td>
+                <td>Mode 4</td>
+                <td>Only the named form's errors, custom wrappers</td>
             </tr>
         </tbody>
     </table>

--- a/assets/reference/included/validation/display_errors.html
+++ b/assets/reference/included/validation/display_errors.html
@@ -4,13 +4,15 @@
   
   <h2>Description</h2>
   <div class="description">
-    <p>Displays validation errors in one of three formats: general HTML list, inline field‑specific errors, or JSON API response. This method is the object‑oriented counterpart to the <code>validation_errors()</code> helper function.</p>
+    <p>Displays validation errors in one of four formats: general HTML list, scoped list for a named form, inline field‑specific errors, or JSON API response. This method is the object‑oriented counterpart to the <code>validation_errors()</code> helper function.</p>
     <p>The format is determined by the <code>first_arg</code> value in the <code>$data</code> array:</p>
     <ul>
       <li><strong>null or omitted</strong> – General errors for all fields (wrapped in <code>&lt;ul class="validation-errors"&gt;</code>)</li>
+      <li><strong>string starting with <code>FORM-</code></strong> – Scoped errors for a named form (e.g. <code>'FORM-login'</code>)</li>
       <li><strong>string (field name)</strong> – Inline errors for a specific field</li>
       <li><strong>integer (400‑499)</strong> – JSON response with HTTP error code</li>
     </ul>
+    <p>Dispatch order: <code>null</code> → <code>json</code> → <code>scoped</code> → <code>inline</code> → <code>standard</code>.</p>
   </div>
   
   <h2>Parameters</h2>
@@ -28,8 +30,9 @@
         <td>array</td>
         <td>Associative array with optional keys:
           <ul>
-            <li><code>first_arg</code> – string|int|null (field name, HTTP code, or null)</li>
+            <li><code>first_arg</code> – string|int|null (field name, <code>FORM-</code> name, HTTP code, or null)</li>
             <li><code>closing_html</code> – ?string (closing HTML tag for general errors)</li>
+            <li><code>scope</code> – ?string (form name for scoped rendering with custom wrappers; standard mode only)</li>
           </ul>
         </td>
       </tr>
@@ -64,6 +67,17 @@
 $errors = $this->validation->display_errors();
 // Returns: &lt;ul class="validation-errors"&gt;...&lt;/ul&gt; or null
 
+// Scoped errors for a named form (default wrappers)
+$login_errors = $this->validation->display_errors(['first_arg' => 'FORM-login']);
+// Returns only the login form's errors, or null on mismatch (abstains without clearing)
+
+// Scoped errors with custom wrappers (position-3 scope spelling)
+$login_errors = $this->validation->display_errors([
+    'first_arg' => '&lt;/p&gt;',
+    'closing_html' => '&lt;p&gt;',
+    'scope' => 'login'
+]);
+
 // Inline errors for specific field
 $email_errors = $this->validation->display_errors(['first_arg' => 'email']);
 // Returns: &lt;ul class="validation-errors validation-errors--inline"&gt;...&lt;/ul&gt; or empty string
@@ -91,10 +105,11 @@ public function submit() {
   
   <h2>Notes</h2>
   <ul>
-    <li>Errors are retrieved from <code>$_SESSION['form_submission_errors']</code>.</li>
+    <li>Errors are retrieved from <code>$_SESSION['form_submission_errors']</code>; the recorded form name lives in <code>$_SESSION['form_submission_name']</code>.</li>
     <li>In JSON mode (HTTP code), the script terminates after output – no return value.</li>
     <li>For inline errors, an empty string is returned if the field has no errors.</li>
     <li>After errors are displayed, they are cleared from session (to prevent duplicate display).</li>
+    <li>A scoped call that does not match the recorded name returns <code>null</code> <strong>without clearing</strong> the bucket — the correct form's block still renders.</li>
     <li>Use the helper <code>validation_errors()</code> for simpler, function‑based access.</li>
   </ul>
 </div>

--- a/assets/reference/included/validation/run.html
+++ b/assets/reference/included/validation/run.html
@@ -110,11 +110,25 @@ public function submit(): void {
   <h2>What Happens When run() is Called</h2>
   <ol>
     <li><strong>CSRF Validation:</strong> Automatically validates CSRF token (unless <code>API_SKIP_CSRF</code> is true)</li>
-    <li><strong>Clear Previous Errors:</strong> Removes any existing validation errors from session</li>
     <li><strong>Process Rules:</strong> Runs validation tests for each field</li>
-    <li><strong>Store Errors:</strong> If errors exist, stores them in <code>$_SESSION['form_submission_errors']</code></li>
-    <li><strong>Return Result:</strong> Returns <code>true</code> (success) or <code>false</code> (failure)</li>
+    <li><strong>On Failure:</strong> Stores the errors in <code>$_SESSION['form_submission_errors']</code>, records which form produced them, and returns <code>false</code></li>
+    <li><strong>On Success:</strong> Clears the error bucket (and the recorded form name) from session, and returns <code>true</code></li>
   </ol>
+
+  <h2>Recording the Form Name (Scoped Validation Errors)</h2>
+  <p>When validation fails, <code>run()</code> also records which form produced the errors, by reading the hidden <code>form_name</code> field injected by <span class="feature-ref">form_open()</span>:</p>
+
+[code=php]
+// The recorded name is stored as:
+$_SESSION['form_submission_name'] = 'login';
+[/code]
+
+  <ul>
+    <li><strong>POST-only:</strong> the name is read from <code>$_POST['form_name']</code>, so GET forms never record a name — consistent with <code>csrf_protect()</code>.</li>
+    <li><strong>Key hygiene:</strong> strings only, trimmed, capped at 64 characters. An array POST (<code>form_name[]=x</code>) or any non-string value can never become a session key.</li>
+    <li>The name is cleared on a successful submission (clear-on-pass) and after errors are rendered.</li>
+    <li>Use the recorded name with the scoped spelling: <code>validation_errors('FORM-login')</code>.</li>
+  </ul>
 
   <h2>Checkbox Validation Example</h2>
   <p>For checkboxes, use <code>required</code> only if the checkbox must be checked:</p>
@@ -141,9 +155,9 @@ public function submit(): void {
   <ul>
     <li>Always compare result with <code>=== true</code> (strict comparison) as <code>run()</code> returns <code>?bool</code></li>
     <li>Errors are automatically stored in session and can be displayed with <code>validation_errors()</code></li>
+    <li>A successful submission clears the error bucket and the recorded form name from session (clear-on-pass)</li>
     <li>For API endpoints where CSRF should be skipped, define <code>define('API_SKIP_CSRF', true);</code></li>
     <li>Empty fields skip validation for most rules (except <code>required</code>)</li>
-    <li>The method clears previous errors from session before running new validation</li>
   </ul>
 
   <div class="alert alert-warning">


### PR DESCRIPTION
Docs pass for the merged validation-errors feature (trongate-framework PRs #256 + #257, issue #237). Signed [Mike] per convention. All pages verified against the v2 spec and the merged framework code.

**Changes (8 files, +200/−19):**

1. **validation_errors.html** — third parameter `?string $scope = null`; new Mode 4 (scoped `FORM-` prefix); position-2-unused flag; abstain-without-clearing semantics; ≤64-char constraint; FOOTGUN warning (scoped call on unnamed form renders nothing); `FORM-*` uppercase reservation.
2. **form_open.html** — Example #5: `form_name` attribute (opt-in, never rendered as HTML attribute, escaped hidden input injected after the opening tag); 64-char cap mirrored from run(); reserved-names callout (`form_name` joins `csrf_token`).
3. **form_close.html** — removed all claims that form_close() clears validation errors (PR-A deleted that unset); documented render-and-clear lifecycle; summary call now safe after form_close().
4. **run.html** — failure branch records `form_submission_name` (POST-only, strings only, trimmed, ≤64); clear-on-pass documented; corrected the 'Clear Previous Errors' step.
5. **display_errors.html** — four render types; dispatch order null → json → scoped → inline → standard; `scope` key in $data; scoped examples.
6. **0010creating_forms.html** — 'Naming a Form' section with form_name example, hidden-field output, and constraints.
7. **0045displaying_validation_errors.html** — four-method table; new Method 2: Scoped Errors; POST-only scoping note; FOOTGUN; placement guidance (summary call safe anywhere — before form, in block, after form_close).
8. **0068csrf_protection.html** — reserved-names note (form_name joins csrf_token) in the Manual Forms section.

**Verified no-change-needed:** 0050the_create_update_pattern.html — inline error placement already canonical; no stale form_close-clears-errors claims.

No MX changes (wire contract byte-identical) — per assignment.