### PR TITLE
[Mike] from_trongate_mx() docs: correct MX request header name (X-Trongate-MX-Request → Trongate-MX-Request)

### DIFF
--- a/assets/reference/helpers/utilities_helpers/from_trongate_mx.html
+++ b/assets/reference/helpers/utilities_helpers/from_trongate_mx.html
@@ -18,7 +18,7 @@
     <tbody>
       <tr>
         <td>bool</td>
-        <td>Returns <code>true</code> if the request has the <code>X-Trongate-MX-Request</code> header set to <code>true</code>, otherwise <code>false</code>.</td>
+        <td>Returns <code>true</code> if the request has the <code>Trongate-MX-Request</code> header set to <code>true</code>, otherwise <code>false</code>.</td>
       </tr>
     </tbody>
   </table>
@@ -34,5 +34,5 @@ if (from_trongate_mx()) {
 [/code]
 
   <h2>Notes</h2>
-  <p>The function checks specifically for the <code>X-Trongate-MX-Request</code> header. If the header is not present or is set to a value other than <code>true</code>, the function will return <code>false</code>. Ensure that the header is correctly set in requests where this function needs to be utilized.</p>
+  <p>The function checks specifically for the <code>Trongate-MX-Request</code> header. If the header is not present or is set to a value other than <code>true</code>, the function will return <code>false</code>. Ensure that the header is correctly set in requests where this function needs to be utilized.</p>
 </div>


### PR DESCRIPTION
Fixes the helper reference page for `from_trongate_mx()` (`assets/reference/helpers/utilities_helpers/from_trongate_mx.html`).

**The error:** both occurrences (:21, :37) name the request header as `X-Trongate-MX-Request` — it carries an `X-` prefix that the framework never sends or checks.

**Verified against framework master `4df5e7b`:**
- `public/js/trongate-mx.js:189` — `http.setRequestHeader('Trongate-MX-Request', 'true')` (no `X-` prefix)
- `modules/utilities/Utilities.php:188-194` — checks `$_SERVER['HTTP_TRONGATE_MX_REQUEST']`, i.e. header `Trongate-MX-Request`; docblock (:185-187) already says `Trongate-MX-Request`
- The MX book's own identifying page (`trongate_mx/0020Core_HTTP_Operations/0050identifying_trongate_mx_requests.html:10`) documents the header correctly as `Trongate-MX-Request: true`

**Fix:** `X-Trongate-MX-Request` → `Trongate-MX-Request` (2 lines). No other pages carry the wrong spelling (repo-wide grep clean).

Found during Unit 1 of the training programme (engine/helpers verification) — same class as PR #255 (framework docblock fix, merged). — Mike