### PR TITLE
[Mike] CRUD complete example: move validation_errors() after form_open() (scoped-validation contract)

### DIFF
--- a/assets/trongate_way/0030Basic_CRUD_System/0070complete_example_and_summary.html
+++ b/assets/trongate_way/0030Basic_CRUD_System/0070complete_example_and_summary.html
@@ -23,7 +23,6 @@
 
   [code=vf]
 &lt;h1&gt;&lt;?= $headline ?&gt;&lt;/h1&gt;
-&lt;?= validation_errors() ?&gt;
 &lt;div class=&quot;card&quot;&gt;
     &lt;div class=&quot;card-heading&quot;&gt;
         Country Details
@@ -31,6 +30,7 @@
     &lt;div class=&quot;card-body&quot;&gt;
         &lt;?php
         echo form_open($form_location);
+        echo validation_errors();
 
         echo form_label(&apos;Country Title&apos;);
         $country_title_attr = [


### PR DESCRIPTION
Closes the last #237 (scoped validation errors) docs leftover, per Grady's tally (`docs PR (0070:26)`).

**Problem:** `trongate_way/0030Basic_CRUD_System/0070complete_example_and_summary.html:26` renders the summary `validation_errors()` call BEFORE `form_open()` (line 33). Under the scoped-validation contract shipped in 2.2026.0823 (PRs #256+#257), pre-open placement keeps whole-bucket/global semantics; the documented canonical pattern (0045displaying_validation_errors.html, Method 2) places the call after `form_open()`.

**Fix:** moved the call — `echo validation_errors();` now immediately follows `echo form_open($form_location);` inside the card-body. One line, one chapter.