### PR TITLE
Preventing URL Invocation: document all three mechanisms (block_url, method visibility, underscore-first as legacy)

### DIFF
--- a/assets/php_framework/0045Intercepting_Requests/0030preventing_url_invocation.html
+++ b/assets/php_framework/0045Intercepting_Requests/0030preventing_url_invocation.html
@@ -245,7 +245,7 @@ class Tax extends Trongate {
 <p>For <b>new</b> Trongate v2 code, prefer <code>block_url()</code> for public-but-internal methods (explicit, self-documenting, <code>403</code>) and <code>private</code> visibility for methods that are only ever called from inside their own class — where no guard is needed at all (see below).</p>
 
 <div class="alert alert-info">
-    <p><strong>Note:</strong> The underscore is a <i>routing</i> convention, not a visibility marker. Underscore-prefixed methods remain public in the PHP sense - they are simply unreachable via the URL. This is what distinguishes the technique from <code>private</code> and <code>protected</code> methods, which the framework's dispatcher rejects with a clean <code>404</code> (since release 2.2026.0823) and which PHP itself refuses to call from outside the class.</p>
+    <p><strong>Note:</strong> The underscore is a <i>routing</i> convention, not a visibility marker. Underscore-prefixed methods remain public in the PHP sense - they are simply unreachable via the URL. This is what distinguishes the technique from <code>private</code> and <code>protected</code> methods, which the framework's dispatcher rejects with a clean <code>404</code> (since release 2.2026.0801) and which PHP itself refuses to call from outside the class.</p>
 </div>
 
 <div class="alert alert-success">
@@ -267,7 +267,7 @@ class Tax extends Trongate {
 
 <h2>PHP Method Visibility: The Simplest Guard</h2>
 
-<p>Since release 2.2026.0823, Trongate v2 blocks URL invocation of <code>private</code> and <code>protected</code> controller methods. The dispatcher reflects on the target method and, if it is not public, returns a clean <code>404 Not Found</code> — exactly as if the page did not exist. (Before this release, such a request produced a PHP fatal error and a <code>500</code> response.)</p>
+<p>Since release 2.2026.0801, Trongate v2 blocks URL invocation of <code>private</code> and <code>protected</code> controller methods. The dispatcher reflects on the target method and, if it is not public, returns a clean <code>404 Not Found</code> — exactly as if the page did not exist. (Before this release, such a request produced a PHP fatal error and a <code>500</code> response.)</p>
 
 [code=php]&lt;?php
 class Tax extends Trongate {
@@ -327,7 +327,7 @@ class Tax extends Trongate {
         </tr>
         <tr>
             <td>PHP method visibility (<code>private</code> / <code>protected</code>)</td>
-            <td>404 Not Found (since 2.2026.0823; fatal 500 before)</td>
+            <td>404 Not Found (since 2.2026.0801; fatal 500 before)</td>
             <td>No — own class only</td>
             <td>No — PHP error</td>
             <td>Methods called only from inside their own class; no guard code wanted</td>

--- a/assets/php_framework/0045Intercepting_Requests/0030preventing_url_invocation.html
+++ b/assets/php_framework/0045Intercepting_Requests/0030preventing_url_invocation.html
@@ -1,4 +1,4 @@
-[meta-description]Trongate offers two ways to prevent browser access to methods: the explicit block_url() helper and the underscore-first naming convention. Both keep methods fully callable from code.[/meta-description]
+[meta-description]Trongate offers three ways to prevent browser access to methods: the block_url() helper, PHP method visibility (private/protected), and the legacy underscore-first naming convention. All three stop direct URL invocation; block_url() and the underscore convention keep methods callable from other code.[/meta-description]
 
 <h1>Preventing URL Invocation</h1>
 
@@ -196,9 +196,13 @@ class Members extends Trongate {
 
 <hr>
 
-<h2>An Alternative: The Underscore-First Technique</h2>
+<h2>A Legacy Approach: The Underscore-First Technique</h2>
 
-<p>Trongate v1 veterans will remember a simpler approach, and it remains fully supported in Trongate v2: prefix any method name with an underscore (<code>_</code>) and the framework will refuse to invoke it via the URL.</p>
+<p>Trongate v1 veterans will remember a simpler approach, and it remains supported in Trongate v2 for migrating existing codebases: prefix any method name with an underscore (<code>_</code>) and the framework will refuse to invoke it via the URL.</p>
+
+<div class="alert alert-warning">
+    <p><strong>Legacy convention — not for new code.</strong> The underscore-first technique is a v1 relic. Trongate v2 still honours it (a clean <code>404</code> at the routing stage, before the controller loads), but new code should use <code>block_url()</code> for public-but-internal methods, or PHP method visibility (<code>private</code>) where the method is only ever called from inside its own class.</p>
+</div>
 
 <p>Any method whose name begins with an underscore can <b>never</b> be triggered by navigating to a URL. The framework intercepts the request <i>before</i> the controller is even loaded and returns a <code>404 Not Found</code> response.</p>
 
@@ -231,25 +235,24 @@ class Tax extends Trongate {
 
 <p>Because enforcement happens at the routing stage, the protection is automatic: every underscore-prefixed method in every module is protected, with no extra code required on your part.</p>
 
-<h3>Why You Might Choose It</h3>
+<h3>Why It Exists</h3>
 
 <ul>
+    <li><b>Migration only</b> - existing v1 codebases carry the convention straight over to Trongate v2 unchanged</li>
     <li><b>Zero boilerplate</b> - the technique requires no code; the underscore <i>is</i> the declaration</li>
-    <li><b>Automatic</b> - every underscore method is protected, so one cannot be forgotten</li>
-    <li><b>Self-documenting</b> - a glance at the method name tells other developers it is internal</li>
-    <li><b>Familiar to v1 developers</b> - existing conventions carry straight over from Trongate v1</li>
 </ul>
 
+<p>For <b>new</b> Trongate v2 code, prefer <code>block_url()</code> for public-but-internal methods (explicit, self-documenting, <code>403</code>) and <code>private</code> visibility for methods that are only ever called from inside their own class — where no guard is needed at all (see below).</p>
+
 <div class="alert alert-info">
-    <p><strong>Note:</strong> The underscore is a <i>routing</i> convention, not a visibility marker. Underscore-prefixed methods remain public in the PHP sense - they are simply unreachable via the URL. This is what distinguishes the technique from <code>private</code> and <code>protected</code> methods, which PHP itself prevents from being called from outside the class.</p>
+    <p><strong>Note:</strong> The underscore is a <i>routing</i> convention, not a visibility marker. Underscore-prefixed methods remain public in the PHP sense - they are simply unreachable via the URL. This is what distinguishes the technique from <code>private</code> and <code>protected</code> methods, which the framework's dispatcher rejects with a clean <code>404</code> (since release 2.2026.0823) and which PHP itself refuses to call from outside the class.</p>
 </div>
 
 <div class="alert alert-success">
     <p><b>Use the underscore-first technique when:</b></p>
     <ul>
-        <li>You want a concise, convention-based alternative to <code>block_url()</code></li>
-        <li>Every method in a controller that starts with <code>_</code> should be internal</li>
-        <li>You are migrating from Trongate v1 and wish to keep existing conventions</li>
+        <li>You are migrating a Trongate v1 codebase and wish to keep existing conventions</li>
+        <li>You are working on legacy code that already uses the convention</li>
     </ul>
 
     <p><b>Use </b><code>block_url()</code><b> when:</b></p>
@@ -259,6 +262,85 @@ class Tax extends Trongate {
         <li>You need to protect a method whose name you cannot change</li>
     </ul>
 </div>
+
+<hr>
+
+<h2>PHP Method Visibility: The Simplest Guard</h2>
+
+<p>Since release 2.2026.0823, Trongate v2 blocks URL invocation of <code>private</code> and <code>protected</code> controller methods. The dispatcher reflects on the target method and, if it is not public, returns a clean <code>404 Not Found</code> — exactly as if the page did not exist. (Before this release, such a request produced a PHP fatal error and a <code>500</code> response.)</p>
+
+[code=php]&lt;?php
+class Tax extends Trongate {
+
+  public function index(): void {
+    $total = $this-&gt;calculate_tax(100);
+    echo 'Total: ' . $total;
+  }
+
+  private function calculate_tax(int $amount): int {
+    return (int) round($amount * 1.2);
+  }
+
+}[/code]
+
+<p>The result:</p>
+
+<ul>
+    <li><code>/tax/index</code> → ✓ Works</li>
+    <li><code>/tax/calculate_tax</code> → ✗ Returns 404 Not Found</li>
+    <li><code>$this-&gt;calculate_tax(100)</code> → ✓ Works from code (in-class call)</li>
+</ul>
+
+<div class="alert alert-danger">
+    <p><strong>Modules::run() limitation:</strong> <code>Modules::run()</code> performs no visibility check — it only tests that the method exists. Calling a <code>private</code> or <code>protected</code> method via <code>Modules::run()</code> from outside the class produces a PHP error, not a 404. Visibility is the strictest cage: such methods are callable <i>only</i> from inside their own class. If a method must stay callable from other code (for example, a validation callback or a cross-module helper), use <code>block_url()</code> rather than <code>private</code>.</p>
+</div>
+
+<div class="alert alert-success">
+    <p><b>Use </b><code>private</code><b> (or <code>protected</code>) when:</b></p>
+    <ul>
+        <li>The method is only ever called from inside its own class</li>
+        <li>You want the strictest possible guarantee with zero guard code — nothing URL-reachable, and not reachable via <code>Modules::run()</code></li>
+    </ul>
+</div>
+
+<hr>
+
+<h2>Comparison: The Three Mechanisms</h2>
+
+<table>
+    <thead>
+        <tr>
+            <th>Mechanism</th>
+            <th>Direct URL response</th>
+            <th>Callable from other code</th>
+            <th>Callable via Modules::run()</th>
+            <th>When to use</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><code>block_url('module/method')</code></td>
+            <td>403 Forbidden</td>
+            <td>Yes</td>
+            <td>Yes</td>
+            <td>Public-but-internal methods — validation callbacks, cross-module helpers</td>
+        </tr>
+        <tr>
+            <td>PHP method visibility (<code>private</code> / <code>protected</code>)</td>
+            <td>404 Not Found (since 2.2026.0823; fatal 500 before)</td>
+            <td>No — own class only</td>
+            <td>No — PHP error</td>
+            <td>Methods called only from inside their own class; no guard code wanted</td>
+        </tr>
+        <tr>
+            <td>Underscore-first names (<code>_method</code>)</td>
+            <td>404 Not Found (routing stage)</td>
+            <td>Yes</td>
+            <td>Yes</td>
+            <td>Legacy v1 code being migrated; not for new code</td>
+        </tr>
+    </tbody>
+</table>
 
 <div class="alert alert-danger">
     <p><strong>Gotcha:</strong> methods whose names contain the literal string <code>_module</code> (for example, <code>submit_module</code>) are intercepted by Trongate's asset-serving route and can never be invoked via the URL. When naming methods, avoid the <code>_module</code> substring.</p>


### PR DESCRIPTION
## Scope

Authenticated against framework source and mirrored here per the Mike brief (EXCHANGE, 2026-08-25). All findings verified against `trongate/trongate-framework` @ `4df5e7b`:

- `engine/Core.php` `invoke_controller_method()`: `method_exists()` is visibility-blind, then `ReflectionMethod::isPublic()` guard → clean 404. Commit `e2b0c12` (PR #249), shipped 2.2026.0823.
- `serve_controller()`: `str_starts_with($this->current_method, '_')` → 404 at routing stage.
- `engine/Modules.php` `run()`: only `method_exists()` is checked, then a direct call — no visibility check, so private/protected methods via `Modules::run()` from outside the class produce a PHP error, not a 404.

## Changes to `0030preventing_url_invocation.html`

1. Meta-description: `two ways` → `three ways`, naming all three mechanisms.
2. **New section — PHP Method Visibility**: clean 404 since 2.2026.0823 (fatal 500 before), code example, and the `Modules::run()` limitation called out.
3. **New comparison table**: mechanism | direct URL response | callable from other code | callable via `Modules::run()` | when to use.
4. Corrected the passing note to reference the framework's explicit 404 guard rather than PHP semantics alone.
5. **Reframed the underscore-first technique as legacy** (per David's ruling): supported for migration, not recommended for new code; `block_url()` presented as the v2-favoured approach; `private` noted as needing no guard.

## Follow-up

The 2.2026.0823 CHANGELOG entry in the framework repo claims three *documented* mechanisms and that `Modules::run()` is unaffected — being corrected separately in `trongate/trongate-framework` (PR to follow).